### PR TITLE
Add optional --umask flag for users to set umask on entry

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -498,6 +498,10 @@ int enter(struct entry_settings *opts)
 		}
 	}
 
+	if (opts->umask != (mode_t) -1) {
+		umask(opts->umask);
+	}
+
 	execvpe(opts->pathname, opts->argv, opts->envp);
 	err(1, "execvpe");
 }

--- a/enter.h
+++ b/enter.h
@@ -63,6 +63,8 @@ struct entry_settings {
 
 	struct timespec clockspecs[MAX_CLOCK + 1];
 
+	mode_t umask;
+
 	const char *arch;
 
 	int no_fake_devtmpfs;

--- a/main.c
+++ b/main.c
@@ -41,6 +41,7 @@ enum {
 	OPTION_DOMAIN,
 	OPTION_TIME,
 	OPTION_PERSIST,
+	OPTION_UMASK,
 	OPTION_NO_FAKE_DEVTMPFS,
 	OPTION_NO_DERANDOMIZE,
 	OPTION_NO_PROC_REMOUNT,
@@ -95,8 +96,9 @@ int usage(int error, char *argv0)
 int main(int argc, char *argv[], char *envp[])
 {
 	static struct entry_settings opts = {
-		.uid = -1,
-		.gid = -1,
+		.uid   = -1,
+		.gid   = -1,
+		.umask = -1,
 	};
 
 	static struct option options[] = {
@@ -125,6 +127,7 @@ int main(int argc, char *argv[], char *envp[])
 		{ "domainname",         required_argument, NULL, OPTION_DOMAIN          },
 		{ "time",               required_argument, NULL, OPTION_TIME            },
 		{ "persist",            required_argument, NULL, OPTION_PERSIST         },
+		{ "umask",              required_argument, NULL, OPTION_UMASK           },
 
 		/* Opt-out feature flags */
 		{ "no-fake-devtmpfs",   no_argument, NULL, OPTION_NO_FAKE_DEVTMPFS      },
@@ -316,6 +319,12 @@ int main(int argc, char *argv[], char *envp[])
 				opts.persist = optarg;
 				break;
 				
+			case OPTION_UMASK:
+				if (sscanf(optarg, "%o", &opts.umask) != 1) {
+					err(2, "%s is not a valid umask", optarg);
+				}
+				break;
+
 			case OPTION_NO_FAKE_DEVTMPFS:
 				opts.no_fake_devtmpfs = 1;
 				break;

--- a/test/bst.t
+++ b/test/bst.t
@@ -69,6 +69,14 @@ Testing mount semantics
 	bst: missing argument(s) to --mount
 	[1]
 
+Testing umask semantics
+
+	$ bst --umask 000 sh -c umask
+	0000
+
+	$ bst --umask 012 sh -c umask
+	0012
+
 Testing workdir semantics
 
 	$ [ "$(bst pwd)" = "$(pwd)" ]


### PR DESCRIPTION
Currently the umask from the caller's environment leaks into the spacetime and
can affect the resulting snapshot.

Rather than relying on users to explicitly set their umask, bst will set it
to 022 for all users.