### PR TITLE
Persisted namespace fixes and unprivileged unpersist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *.o
+*.gz
+*.t.err
 bst
-/bestie.*.apk
-/bestie.*.deb
-/bestie.*.rpm
-/bestie.*.tgz
-/bst.1.gz
+bst-unpersist

--- a/bst-unpersist.1.scd
+++ b/bst-unpersist.1.scd
@@ -1,0 +1,38 @@
+bst-unpersist(1) "bst" "Bestie"
+
+# NAME
+
+bst-unpersist - release persisted namespace files
+
+# SYNOPSIS
+
+bst-unpersist [options] <path> [path...]
+
+# DESCRIPTION
+
+Releases persisted specified namespace files, or all known namespace files
+in the specified directories.
+
+*bst*(1) can persist created namespaces on entry via the _--persist_ option.
+A typical way to release these persisted namespaces is through the unmounting
+of these files, but this requires the user to be privileged.
+
+*bst-unpersist* gives unprivilged users a way to release these persisted
+namespaces without privilege escalation.
+
+A user is allowed to release an arbitrary namespace file only if:
+
+. It is an nsfs mount,
+. The user has write permissions over the containing directory, or has
+  CAP_DAC_OVERRIDE.
+
+# OPTIONS
+
+\--no-unlink
+	Do not remove namespace file mountpoints after they get unmounted.  This
+	use-case is atypical, but is useful if you plan to layer multiple nsfs
+	mounts on top of each other, and don't want the removal to fail with EBUSY.
+
+# SEE ALSO
+
+*bst*(1)

--- a/bst.1.scd
+++ b/bst.1.scd
@@ -52,13 +52,19 @@ Users of bst may choose to opt-out of some of the isolation.
 	namespace.
 
 \--persist <dir>
-	Bind-mount all namespaces of the new process into files in the
-	given directory.  The files are named the same as the
-	namespace files in /proc/[pid]/ns.  This option is equivalent
-	to bind-mounting /proc/[pid]/ns/\* into *<dir>*/\* after invoking
-	bst, except avoiding a race where the child exits before the
-	bind-mounts complete.  Note that the persist directory must
-	be on a private mount or bind-mounting fails with EINVAL.
+	Persist all namespaces of the new process into files in the
+	given directory, allowing re-entry via _--share-\*=<dir>_ even after bst
+	exits (but note that pid namespaces whose init died cannot be re-entered).
+
+	The files are named the same as the namespace files in /proc/[pid]/ns.
+	This option is equivalent to bind-mounting /proc/[pid]/ns/\* into
+	*<dir>*/\* after invoking bst, except avoiding a race where the child
+	exits before the bind-mounts complete.  Note that in order to persist the
+	mount namespace, the persist directory must be on a private mount subtree
+	(for more information, see *mount_namespaces*(7)).
+
+	See *bst-unpersist*(1) for more details about how to release persisted
+	namespace files.
 
 \--workdir <dir>
 	Change the current work directory for the inner process to *<dir>*.
@@ -180,4 +186,4 @@ Users of bst may choose to opt-out of some of the isolation.
 
 # SEE ALSO
 
-*namespaces*(7), *mount*(1), *setarch*(1)
+*bst-unpersist*(1), *namespaces*(7), *mount*(1), *setarch*(1)

--- a/enter.c
+++ b/enter.c
@@ -495,6 +495,18 @@ int enter(struct entry_settings *opts)
 		if (child == -1) {
 			err(1, "fork");
 		} else if (child) {
+
+			/* bst is effectively a setuid binary. This means that by default,
+			   it has its dumpability set to the value of
+			   /proc/sys/fs/suid_dumpable, which likely changes the ownership
+			   of its own /proc/pid/ directory. This means that we can't use
+			   nsenter and friends to probe this init's /proc/pid/ns.
+
+			   Setting the dumpable flag fixes this. */
+			if (prctl(PR_SET_DUMPABLE, 1) == -1) {
+				err(1, "prctl(PR_SET_DUMPABLE)");
+			}
+
 			init(child);
 			__builtin_unreachable();
 		}

--- a/enter.c
+++ b/enter.c
@@ -74,6 +74,8 @@ enum {
       NSACTION_UNSHARE = -2,
 };
 
+char share_with_parent[0];
+
 static void opts_to_nsactions(const struct entry_settings *opts, int *nsactions)
 {
 	for (int i = 0; i < MAX_SHARES; i++) {

--- a/enter.h
+++ b/enter.h
@@ -33,7 +33,7 @@ enum {
 const char *nsname(int);
 
 /* share_with_parent is a special value for entry_settings.shares[ns]. */
-char share_with_parent[0];
+extern char share_with_parent[0];
 
 struct entry_settings {
 	/* shares[] is indexed by SHARE_CGROUP, etc.  Legal values are:

--- a/test/bst.t
+++ b/test/bst.t
@@ -120,4 +120,4 @@ Testing hostname semantics
 
 Testing persistence
 
-	$ [ ! -d foo ] && [ ! -d bar ] && mkdir -p foo bar && bst --persist=foo sh -c 'mount -t tmpfs none bar && echo hello > bar/greeting' && [ ! -f bar/greeting ] && sudo nsenter --mount=foo/mnt bash -c '[ "$(cat '"$PWD"'/bar/greeting)" == "hello" ]' && sudo umount foo/* && [ -d foo ] && rm -rf foo bar && [ ! -d foo ] && [ ! -d bar ]
+	$ mkdir -p foo bar; trap 'bst-unpersist foo && rmdir foo bar' EXIT; bst --persist=foo sh -c 'mount -t tmpfs none bar && echo hello > bar/greeting' && [ ! -f bar/greeting ] && bst --share-mnt=foo/mnt --share-user=foo/user sh -c '[ "$(cat '"$PWD"'/bar/greeting)" = "hello" ]'

--- a/unpersist.c
+++ b/unpersist.c
@@ -1,0 +1,275 @@
+/* Copyright © 2020 Arista Networks, Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the MIT license that can be found
+ * in the LICENSE file.
+ */
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/capability.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#define NSFS_DEV (makedev(0, 4))
+
+static bool capable(cap_value_t cap)
+{
+	static cap_t caps;
+
+	if (!caps) {
+		caps = cap_get_proc();
+	}
+
+	cap_flag_value_t set;
+	if (cap_get_flag(caps, cap, CAP_EFFECTIVE, &set) == -1) {
+		err(1, "cap_get_flag");
+	}
+	return set;
+}
+
+static gid_t *get_groups(size_t *ngroups)
+{
+	static gid_t groups[NGROUPS_MAX];
+	static size_t len;
+
+	if (len == 0) {
+		int rc = getgroups(NGROUPS_MAX, groups);
+		if (rc == -1) {
+			err(1, "getgroups");
+		}
+		len = (size_t) rc;
+	}
+
+	*ngroups = len;;
+	return groups;
+}
+
+static int checkperm(const struct stat *stat)
+{
+	if (stat->st_mode & 0002) {
+		return 1;
+	}
+
+	if (stat->st_uid == getuid() && stat->st_mode & 0200) {
+		return 1;
+	}
+
+	if (!(stat->st_mode & 0020)) {
+		return 0;
+	}
+
+	if (stat->st_gid == getgid()) {
+		return 1;
+	}
+
+	size_t ngroups;
+	gid_t *groups = get_groups(&ngroups);
+
+	for (size_t i = 0; i < ngroups; ++i) {
+		if (stat->st_gid == groups[i]) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+enum {
+	UNPERSIST_KEEPFILE = 1,
+};
+
+static int unpersistat(int dirfd, const char *pathname, int flags)
+{
+	/* We are a privileged binary, with the ability to unmount arbitrary files.
+	   We only allow ourselves to unmount something that fulfills two conditions:
+
+	   1. The current uid or gids must have write permissions over the parent
+	      directory.
+	   2. The mount is an nsfs mount.
+
+	   Everything else results from an access violation on our part. */
+
+	int fd = openat(dirfd, pathname, O_PATH | O_NOFOLLOW);
+	if (fd == -1) {
+		goto error;
+	}
+
+	struct stat stat;
+	if (fstat(fd, &stat) == -1) {
+		goto error;
+	}
+
+	if (stat.st_dev != NSFS_DEV) {
+		errno = EPERM;
+		goto error;
+	}
+
+	char selfpath[PATH_MAX];
+	snprintf(selfpath, PATH_MAX, "/proc/self/fd/%d", fd);
+
+	if (dirfd == AT_FDCWD) {
+		char resolved[PATH_MAX];
+		if (readlink(selfpath, resolved, sizeof (resolved)) == -1) {
+			goto error;
+		}
+
+		int dirfd = open(dirname(resolved), O_PATH | O_DIRECTORY);
+		if (dirfd == -1) {
+			goto error;
+		}
+		int rc = fstat(dirfd, &stat);
+		close(dirfd);
+		if (rc == -1) {
+			goto error;
+		}
+	} else if (fstat(dirfd, &stat) == -1) {
+		goto error;
+	}
+
+	if (!capable(CAP_DAC_OVERRIDE) && !checkperm(&stat)) {
+		errno = EACCES;
+		goto error;
+	}
+
+	/* This is subtle -- someone could race against us to swap out the mount
+	   for a symlink to some arbitrary mount between the moment we open the
+	   nsfs file and validate it, and the moment we call umount. Since we can't
+	   trust the path itself, we have to rely on the kernel magic link resolution
+	   to do this for us by unmounting /proc/self/fd/<fd>. */
+
+	if (umount2(selfpath, MNT_DETACH) == -1) {
+		goto error;
+	}
+
+	/* The file descriptor is now useless since it refers to our now-defunct
+	   nsfs file. We have to use the original path for removal, but it's fine,
+	   normal access rules apply here. */
+	if (!(flags & UNPERSIST_KEEPFILE) && unlinkat(dirfd, pathname, 0) == -1) {
+		goto error;
+	}
+
+	return 0;
+
+error:
+	if (fd != -1) {
+		close(fd);
+	}
+	return -1;
+}
+
+static int usage(int error, char *argv0)
+{
+	FILE *out = error ? stderr : stdout;
+	fprintf(out, "usage: %s [options] <path> [path...]\n", argv0);
+	fprintf(out, "\n");
+	fprintf(out, "Unpersist specified namespace files, or all namespace files\n");
+	fprintf(out, "in specified directories.\n");
+	fprintf(out, "\n");
+	fprintf(out, "Options:\n");
+	fprintf(out, "\t-h, --help:   print this message.\n");
+	fprintf(out, "\t--no-unlink: do not attempt to remove nsfs mountpoints.\n");
+	return error ? 2 : 0;
+}
+
+enum {
+	OPTION_NO_UNLINK = 128,
+};
+
+int main(int argc, char *argv[])
+{
+	static struct option options[] = {
+		{ "help",       no_argument,        NULL,   'h' },
+		{ "no-unlink",  no_argument,        NULL,   OPTION_NO_UNLINK },
+		{ 0, 0, 0, 0 }
+	};
+
+	static struct {
+		int unpersistat_flags;
+	} settings;
+
+	int error = 0;
+	int c;
+	while ((c = getopt_long(argc, argv, "h", options, NULL)) != -1) {
+		switch (c) {
+			case 0:
+				break;
+
+			case OPTION_NO_UNLINK:
+				settings.unpersistat_flags |= UNPERSIST_KEEPFILE;
+				break;
+
+			case '?':
+				error = 1;
+				/* fallthrough */
+			case 'h':
+				return usage(error, argv[0]);
+
+			default:
+				for (int i = 0; options[i].name != NULL; i++) {
+					if (options[i].val == c) {
+						if (options[i].flag != NULL) {
+							*options[i].flag = c;
+						}
+						break;
+					}
+				}
+		}
+	}
+
+	if (argc - optind < 1) {
+		return usage(true, argv[0]);
+	}
+
+	const char *namespaces[] = {
+		"cgroup",
+		"ipc",
+		"mnt",
+		"net",
+		"pid",
+		"user",
+		"uts",
+		"time",
+	};
+
+	for (int arg = optind; arg < argc; ++arg) {
+		char *name = argv[arg];
+
+		int dirfd = open(name, O_PATH | O_DIRECTORY);
+		if (dirfd == -1) {
+			if (errno == ENOTDIR) {
+				/* This is a normal filename -- treat it as if we got
+				   passed an nsfs filename. */
+				if (unpersistat(AT_FDCWD, name, settings.unpersistat_flags) == -1) {
+					warn("unpersist \"%s\"", name);
+				}
+				continue;
+			}
+			err(1, "open \"%s\"", name);
+		}
+
+		for (size_t i = 0; i < sizeof (namespaces) / sizeof (*namespaces); ++i) {
+			if (unpersistat(dirfd, namespaces[i], settings.unpersistat_flags) == -1) {
+				switch (errno) {
+				case ENOENT:
+					continue;
+				case EPERM:
+					warnx("ignoring %s/%s: not an nsfs file", name, namespaces[i]);
+					continue;
+				}
+				err(1, "unpersist \"%s/%s\"", name, namespaces[i]);
+			}
+		}
+
+		close(dirfd);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
These are a couple of commits that make the usage of re-entering and persisting namespace easier from an unprivileged user. We shouldn't have to use sudo to clear after a non-sudo operation, nor should we be using sudo to enter the spacetime of a running process that we own.