### PR TITLE
Fix build under alpine

### DIFF
--- a/enter.h
+++ b/enter.h
@@ -9,6 +9,7 @@
 
 # include <limits.h>
 # include <time.h>
+# include <sys/stat.h>
 # include <unistd.h>
 # include "mount.h"
 # include "timens.h"


### PR DESCRIPTION
For some reason, this built fine on my ubuntu laptop as-is, but I was not able to build this under alpine without explicitly importing "sys/types.h".

With this patch, bst now builds successfully in an our barney.ci/bestie environment.