### PR TITLE
Capability code cleanup & privilege model fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ generate: usage.txt
 	 xxd -i usage.txt) > usage.c
 
 bst: $(OBJS)
-	$(LINK.o) -o $@ $^ -lcap
+	$(LINK.o) -o $@ $^
 	$(SETCAP) cap_setuid,cap_setgid,cap_dac_override,cap_sys_admin,cap_sys_ptrace,cap_sys_chroot+p $@ \
 		|| ($(CHOWN) root $@ && $(CHMOD) u+s $@)
 
 bst-unpersist: unpersist.o capable.o
-	$(LINK.o) -o $@ $^ -lcap
+	$(LINK.o) -o $@ $^
 	$(SETCAP) cap_sys_admin+p $@ \
 		|| ($(CHOWN) root $@ && $(CHMOD) u+s $@)
 

--- a/capable.c
+++ b/capable.c
@@ -18,6 +18,8 @@ static struct __user_cap_header_struct hdr = {
 	.version = _LINUX_CAPABILITY_VERSION_3,
 };
 
+int deny_new_capabilities = 0;
+
 /* Normally, using cap(get|set) isn't really advisable, as it's a linux-specific
    interface. But the matter of fact is that bst is already linux-specific, that
    libcap adds a lot of unneeded complexity, and that it operates on dynamic
@@ -39,6 +41,9 @@ bool capable(uint64_t cap)
 
 void make_capable(uint64_t cap)
 {
+	if (deny_new_capabilities) {
+		errx(1, "called make_capable in no-new-capabilities code");
+	}
 	current[0].effective |= (__u32) (cap & (__u32) -1);
 	current[1].effective |= (__u32) (cap >> 32);
 	if (capset(&hdr, current) == -1) {

--- a/capable.h
+++ b/capable.h
@@ -20,6 +20,8 @@
 # define BST_CAP_SETGID         ((uint64_t) 1 << CAP_SETGID)
 # define BST_CAP_SYS_CHROOT     ((uint64_t) 1 << CAP_SYS_CHROOT)
 
+extern int deny_new_capabilities;
+
 void init_capabilities(void);
 bool capable(uint64_t cap);
 void make_capable(uint64_t cap);

--- a/capable.h
+++ b/capable.h
@@ -10,9 +10,19 @@
 # include <stdbool.h>
 # include <sys/capability.h>
 
+/* Define more useful capability constants */
+# define BST_CAP_SYS_ADMIN      ((uint64_t) 1 << CAP_SYS_ADMIN)
+# define BST_CAP_SYS_PTRACE     ((uint64_t) 1 << CAP_SYS_PTRACE)
+# define BST_CAP_DAC_OVERRIDE   ((uint64_t) 1 << CAP_DAC_OVERRIDE)
+# define BST_CAP_SYS_RESOURCE   ((uint64_t) 1 << CAP_SYS_RESOURCE)
+# define BST_CAP_NET_ADMIN      ((uint64_t) 1 << CAP_NET_ADMIN)
+# define BST_CAP_SETUID         ((uint64_t) 1 << CAP_SETUID)
+# define BST_CAP_SETGID         ((uint64_t) 1 << CAP_SETGID)
+# define BST_CAP_SYS_CHROOT     ((uint64_t) 1 << CAP_SYS_CHROOT)
+
 void init_capabilities(void);
-bool capable(cap_value_t cap);
-void make_capable(cap_value_t cap);
+bool capable(uint64_t cap);
+void make_capable(uint64_t cap);
 void reset_capabilities(void);
 
 #endif /* !CAPABLE_H_ */

--- a/enter.c
+++ b/enter.c
@@ -112,7 +112,7 @@ int enter(struct entry_settings *opts)
 		   is unfortunately owned by root and not ourselves, so we have
 		   to give ourselves the capability to read our own file. Geez. */
 
-		make_capable(CAP_DAC_OVERRIDE);
+		make_capable(BST_CAP_DAC_OVERRIDE);
 
 		timens_offsets = open("/proc/self/timens_offsets", O_WRONLY);
 		if (timens_offsets == -1) {
@@ -384,7 +384,7 @@ int enter(struct entry_settings *opts)
 	/* We have a special case for pivot_root: the syscall wants the
 	   new root to be a mount point, so we indulge. */
 	if (mnt_unshare && strcmp(root, "/") != 0) {
-		make_capable(CAP_SYS_ADMIN);
+		make_capable(BST_CAP_SYS_ADMIN);
 
 		if (mount(root, root, "none", MS_BIND|MS_REC, "") == -1) {
 			err(1, "mount(\"/\", \"/\", MS_BIND|MS_REC)");
@@ -414,7 +414,7 @@ int enter(struct entry_settings *opts)
 			}
 		}
 
-		make_capable(CAP_SYS_ADMIN);
+		make_capable(BST_CAP_SYS_ADMIN);
 
 		mount_entries(root, opts->mounts, opts->nmounts, opts->no_derandomize);
 		mount_mutables(root, opts->mutables, opts->nmutables);
@@ -438,7 +438,7 @@ int enter(struct entry_settings *opts)
 		   will burn your house, invoke dragons, and eat your children. */
 
 		if (!mnt_unshare) {
-			make_capable(CAP_SYS_CHROOT);
+			make_capable(BST_CAP_SYS_CHROOT);
 
 			if (chroot(root) == -1) {
 				err(1, "chroot");
@@ -450,7 +450,7 @@ int enter(struct entry_settings *opts)
 				err(1, "pivot_root: pre chdir");
 			}
 
-			make_capable(CAP_SYS_ADMIN);
+			make_capable(BST_CAP_SYS_ADMIN);
 
 			/* Pivot the root to `root` (new_root) and mount the old root
 			   (old_dir) on top of it. Then, unmount "." to get rid of the

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "enter.h"
+#include "capable.h"
 #include "sig.h"
 #include "kvlist.h"
 
@@ -95,6 +96,8 @@ int usage(int error, char *argv0)
 
 int main(int argc, char *argv[], char *envp[])
 {
+	init_capabilities();
+
 	static struct entry_settings opts = {
 		.uid   = -1,
 		.gid   = -1,

--- a/outer.c
+++ b/outer.c
@@ -306,9 +306,7 @@ static void burn_uidmap_gidmap(int child_pid) {
 	id_str = itoa(gid);
 	populate_id_map(gid_map, sizeof (gid_map), "/etc/subgid", id_str, group ? group->gr_name : id_str);
 
-	make_capable(CAP_SETUID);
-	make_capable(CAP_SETGID);
-	make_capable(CAP_DAC_OVERRIDE);
+	make_capable(BST_CAP_SETUID | BST_CAP_SETGID | BST_CAP_DAC_OVERRIDE);
 
 	burn(procfd, "uid_map", uid_map);
 	burn(procfd, "gid_map", gid_map);
@@ -361,8 +359,7 @@ static void persist_ns_files(int pid, const char *persist) {
 		snprintf(persistname, sizeof(persistname), "%s/%s", persist, f->proc_ns_name);
 		persistname[sizeof(persistname) - 1] = 0;
 
-		make_capable(CAP_SYS_ADMIN);
-		make_capable(CAP_SYS_PTRACE);
+		make_capable(BST_CAP_SYS_ADMIN | BST_CAP_SYS_PTRACE);
 
 		int rc = mount(procname, persistname, "", MS_BIND, "");
 

--- a/unpersist.c
+++ b/unpersist.c
@@ -120,7 +120,7 @@ static int unpersistat(int dirfd, const char *pathname, int flags)
 		goto error;
 	}
 
-	if (!capable(CAP_DAC_OVERRIDE) && !checkperm(&stat)) {
+	if (!capable(BST_CAP_DAC_OVERRIDE) && !checkperm(&stat)) {
 		errno = EACCES;
 		goto error;
 	}
@@ -131,7 +131,7 @@ static int unpersistat(int dirfd, const char *pathname, int flags)
 	   trust the path itself, we have to rely on the kernel magic link resolution
 	   to do this for us by unmounting /proc/self/fd/<fd>. */
 
-	make_capable(CAP_SYS_ADMIN);
+	make_capable(BST_CAP_SYS_ADMIN);
 
 	if (umount2(selfpath, MNT_DETACH) == -1) {
 		goto error;


### PR DESCRIPTION
This set of changes fix the last few gripes I've had with the capability code in bst.

First and foremost, libcap is dropped in favor of raw capget/capset code. Whatever the manpage for capget says, the matter of fact is that this new code is simpler, has 0 dynamic allocations, and just allows for the implementation of a better interface.

Second, I've realized that due to some misunderstanding of user namespaces on my end when I first wrote that code, the placement of the mount code (and almost everything after setresuid()) is just wrong. In this fixed version, we no longer need to give ourselves back capabilities after switching uids -- instead, the switch is done almost at the very end, where the only two remaining operations are chdir and execve. These are in fact the only two operations where using the privilege set of the user we're changing to makes sense.