### PR TITLE
Move bst-init to its own executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.t.err
 bst
 bst-unpersist
+bst-init

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
 DATADIR ?= $(PREFIX)/share
+LIBEXECDIR ?= $(PREFIX)/libexec
 MANDIR ?= $(DATADIR)/man
 
 CFLAGS ?= -O2
 CFLAGS += -std=c99 -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing
-CPPFLAGS += -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
+CPPFLAGS += -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DLIBEXECDIR=\"$(LIBEXECDIR)\"
 
-SRCS := main.c enter.c outer.c mount.c cp.c setarch.c usage.c sig.c timens.c path.c kvlist.c init.c net.c capable.c
+SRCS := main.c enter.c outer.c mount.c cp.c setarch.c usage.c sig.c timens.c path.c kvlist.c net.c capable.c
 OBJS := $(subst .c,.o,$(SRCS))
-BINS := bst bst-unpersist
+BINS := bst bst-unpersist bst-init
 
 ifeq ($(shell id -u),0)
 SUDO =
@@ -44,6 +45,9 @@ bst: $(OBJS)
 	$(SETCAP) cap_setuid,cap_setgid,cap_dac_override,cap_sys_admin,cap_sys_ptrace,cap_sys_chroot+p $@ \
 		|| ($(CHOWN) root $@ && $(CHMOD) u+s $@)
 
+bst-init: init.o
+	$(LINK.o) -o $@ $^
+
 bst-unpersist: unpersist.o capable.o
 	$(LINK.o) -o $@ $^
 	$(SETCAP) cap_sys_admin+p $@ \
@@ -52,18 +56,20 @@ bst-unpersist: unpersist.o capable.o
 %.gz: %.scd
 	scdoc <$< | gzip -c >$@
 
-man: bst.1.gz bst-unpersist.1.gz
+man: bst.1.gz bst-unpersist.1.gz bst-init.1.gz
 
 install: BST_INSTALLPATH = $(DESTDIR)$(BINDIR)/bst
 install: $(BINS) man
 	install -m 755 -D bst $(BST_INSTALLPATH)
-	$(SETCAP) cap_setuid,cap_setgid,cap_dac_override,cap_sys_admin,cap_sys_ptrace,cap_sys_chroot+p $(BST_INSTALLPATH) \
-		|| ($(CHOWN) root $(BST_INSTALLPATH) && $(CHMOD) u+s $(BST_INSTALLPATH))
 	install -m 755 -D bst-unpersist $(BST_INSTALLPATH)-unpersist
-	$(SETCAP) cap_sys_admin+p $(BST_INSTALLPATH)-unpersist \
-		|| ($(CHOWN) root $(BST_INSTALLPATH)-unpersist && $(CHMOD) u+s $(BST_INSTALLPATH)-unpersist)
+	install -m 755 -D bst-init $(DESTDIR)$(LIBEXECDIR)/bst-init
 	install -m 644 -D bst.1.gz $(DESTDIR)$(MANDIR)/man1/bst.1.gz
 	install -m 644 -D bst-unpersist.1.gz $(DESTDIR)$(MANDIR)/man1/bst-unpersist.1.gz
+	install -m 644 -D bst-init.1.gz $(DESTDIR)$(MANDIR)/man1/bst-init.1.gz
+	$(SETCAP) cap_setuid,cap_setgid,cap_dac_override,cap_sys_admin,cap_sys_ptrace,cap_sys_chroot+p $(BST_INSTALLPATH) \
+		|| ($(CHOWN) root $(BST_INSTALLPATH) && $(CHMOD) u+s $(BST_INSTALLPATH))
+	$(SETCAP) cap_sys_admin+p $(BST_INSTALLPATH)-unpersist \
+		|| ($(CHOWN) root $(BST_INSTALLPATH)-unpersist && $(CHMOD) u+s $(BST_INSTALLPATH)-unpersist)
 
 check: export PATH := $(DESTDIR)$(BINDIR):${PATH}
 check: $(BINS)

--- a/bst-init.1.scd
+++ b/bst-init.1.scd
@@ -1,0 +1,21 @@
+bst-init(1) "bst" "Bestie"
+
+# NAME
+
+bst-init - default bst init process.
+
+# SYNOPSIS
+
+bst-init [executable [args...]]
+
+# DESCRIPTION
+
+*bst-init* is the default init process employed by *bst*(1) when unsharing
+the PID namespace.
+
+*bst-init* forks and executes _<executable>_, only reaps zombies, and
+immediately terminates when _<executable>_ exits.
+
+# SEE ALSO
+
+*bst*(1), *init*(1), *pid_namespaces*(7)

--- a/bst.1.scd
+++ b/bst.1.scd
@@ -145,6 +145,18 @@ Users of bst may choose to opt-out of some of the isolation.
 
 	You cannot use this option with _--share=time_.
 
+\--init <argv>
+	Set the init process to be used as parent of *<executable>*. *<argv>* is
+	a space-delimited argv array, and _argv[0]_ must be an absolute path to a
+	valid executable in the current filesystem root (in other words, the init
+	executable does not need to exist in the root specified by _--root_).
+
+	If an empty *<argv>* is passed to _--init_, no init process will be
+	spawed by bst, and *<executable>* will be executed directly.
+
+	If bst unshares the pid namespace and no _--init_ is specified, it uses
+	by default *bst-init*(1).
+
 \--no-fake-devtmpfs
 	Do not replace devtmpfs mounts with a fake devtmpfs.
 
@@ -167,15 +179,6 @@ Users of bst may choose to opt-out of some of the isolation.
 	By default, *bst* automatically tries to mount a new procfs on top of _/proc_
 	if it detects it to be on another filesystem than _/_.
 
-\--no-init
-	Do not use *bst*'s minimal init process.
-
-	By default, *bst* automatically spawns a bare-bones init process in a PID
-	namespace, which only reaps zombies, and immediately terminates when the
-	spawned process of _<executable>_ exits.
-
-	This does nothing when used with _--share=pid_.
-
 \--no-loopback-setup
 	Do not bring up the _lo_ interface.
 
@@ -186,4 +189,4 @@ Users of bst may choose to opt-out of some of the isolation.
 
 # SEE ALSO
 
-*bst-unpersist*(1), *namespaces*(7), *mount*(1), *setarch*(1)
+*bst-unpersist*(1), *bst-init*(1), *namespaces*(7), *mount*(1), *setarch*(1)

--- a/enter.c
+++ b/enter.c
@@ -409,12 +409,6 @@ int enter(struct entry_settings *opts)
 
 	int initfd = -1;
 	if (opts->init_argv != NULL && opts->init_argv[0] != NULL) {
-		if (nsactions[SHARE_PID] >= 0) {
-			errx(1, "cannot specify init process when entering an arbitrary pid namespace");
-		}
-		if (!pid_unshare) {
-			errx(1, "cannot specify init process when not in a pid namespace");
-		}
 		initfd = open(opts->init_argv[0], O_PATH);
 		if (initfd == -1) {
 			err(1, "open %s", opts->init_argv[0]);
@@ -492,6 +486,11 @@ int enter(struct entry_settings *opts)
 	}
 
 	if (initfd != -1) {
+
+		if (!pid_unshare && prctl(PR_SET_CHILD_SUBREAPER, 1) == -1) {
+			err(1, "prctl: could not set init as child subreaper");
+		}
+
 		/* This size estimation is an overkill upper bound, but oh well... */
 		char *argv[ARG_MAX];
 		size_t argc = 0;

--- a/enter.h
+++ b/enter.h
@@ -46,6 +46,7 @@ struct entry_settings {
 	const char *pathname;
 	char *const *argv;
 	char *const *envp;
+	char *const *init_argv;
 	char *root;
 	char *workdir;
 

--- a/usage.txt
+++ b/usage.txt
@@ -30,9 +30,9 @@ Options:
 	--hostname <host>:      Set the host name.
 	--domainname <domain>:  Set the domain name.
 	--time <name>=<s>[.ns]: Set the time of a specific clock.
+	--init=<init-argv>:     Use the specified outer path as init process.
 
 	--no-fake-devtmpfs:     Don't replace devtmpfs mounts with fake ones.
 	--no-derandomize:       Don't attempt to reduce randomness sources.
 	--no-proc-remount:      Don't remount the existing /proc in pid namespaces.
-	--no-init:              Don't use the builtin init process.
 	--no-loopback-setup:    Don't bring the lo interface up in network namespaces.


### PR DESCRIPTION
The first commit splits out bst-init into its own executable. This has a
bunch of interesting properties for bst:

First, it allows us to rewrite the process cmdline without doing
anything too crazy (*cough* PR_SET_MM_MAP), which helps tools
distinguish bst from its init process

Second, we don't need to explicitly mark the init as dumpable to let
inner processes with root privileges look at /proc/1/*.

Third, this lets us implement --init, which allows user to specify an
init process of their choosing, should the behaviour of *bst-init* not be
adapted to the situation they're in.

This supersedes #12.

The second commit is optional. I wanted to see if `bst --init=/some/init --share-pid` was even correct, but it turns out we can give it reasonable semantics. A somewhat interesting use-case is catching daemons that try to escape while still operating in the parent pid namespace.