### PR TITLE
mount: add default /dev/ptmx and /dev/tty to bst_devtmpfs

### DIFF
--- a/mount.c
+++ b/mount.c
@@ -249,6 +249,7 @@ void mount_entries(const char *root, const struct mount_entry *mounts, size_t nm
 				{ "stdin", "/proc/self/fd/0" },
 				{ "stdout", "/proc/self/fd/1" },
 				{ "stderr", "/proc/self/fd/2" },
+				{ "ptmx", "/dev/pts/ptmx" },
 				{ "random", "zero" },
 				{ "urandom", "zero" },
 			};

--- a/mount.c
+++ b/mount.c
@@ -198,6 +198,7 @@ void mount_entries(const char *root, const struct mount_entry *mounts, size_t nm
 				{ "null",    S_IFCHR | 0666, makedev(1, 3) },
 				{ "full",    S_IFCHR | 0666, makedev(1, 7) },
 				{ "zero",    S_IFCHR | 0666, makedev(1, 5) },
+				{ "tty",     S_IFCHR | 0666, makedev(5, 0) },
 				{ "random",  S_IFCHR | 0666, makedev(1, 8) },
 				{ "urandom", S_IFCHR | 0666, makedev(1, 9) },
 			};


### PR DESCRIPTION
These add /dev/ptmx and /dev/tty to the fake devtmpfs mount.