### PR TITLE
misc: fix segfault with empty --init arg

### DIFF
--- a/main.c
+++ b/main.c
@@ -488,7 +488,7 @@ int main(int argc, char *argv[], char *envp[])
 	}
 	char *new_argv[argc - optind + 1];
 
-	if (!argv0 && opts.init) {
+	if (!argv0 && opts.init && opts.init[0] != '\0') {
 		argv0 = (char *) opts.init + strlen(opts.init) - 1;
 		for (; argv0 != opts.init && *argv0 != '/'; --argv0) {
 			continue;


### PR DESCRIPTION
The "Program must be init of its pid namespace if no init is
specified" test would sometimes fail with a segmentation fault, and it
turns out the reason was that it would start searching backward for a
`/` at `opts.init` memory, wanting to stop no earlier than `opts.init`
itself, but it was starting one byte before, and so walked off into
strange places!

Check if `opts.init` is an empty string and skip this search if it is.