### PR TITLE
wip: enter: allow bst process to enter cgroups

### DIFF
--- a/enter.h
+++ b/enter.h
@@ -20,6 +20,14 @@
 enum {
 	MAX_MOUNT = 4096,
 	MAX_NICS = 4096,
+
+	// There are 13 cgroup controllers, so the max theoretical limit for combined
+	// mounted is 2^13 (sum of 13 choose k for k from 1 to 13, plus 1 cgroupv2 mount).
+	//
+	// It's very unlikely that any sane system has 8192 active cgroup mounts,
+	// but memory is supremely cheap, and I doubt we'll have to change that value
+	// for the forseeable future.
+	MAX_CGROUPS = 8192,
 };
 
 /* SHARE_WITH_PARENT is a special value for entry_settings.shares[ns]. */
@@ -60,6 +68,8 @@ struct entry_settings {
 	size_t nnics;
 
 	mode_t umask;
+	const char *cgroups[MAX_CGROUPS];
+	size_t ncgroups;
 
 	const char *arch;
 

--- a/main.c
+++ b/main.c
@@ -47,6 +47,7 @@ enum {
 	OPTION_UIDMAP,
 	OPTION_GIDMAP,
 	OPTION_NIC,
+	OPTION_CGROUP,
 	OPTION_NO_FAKE_DEVTMPFS,
 	OPTION_NO_DERANDOMIZE,
 	OPTION_NO_PROC_REMOUNT,
@@ -141,6 +142,7 @@ int main(int argc, char *argv[], char *envp[])
 		{ "uid-map",            required_argument, NULL, OPTION_UIDMAP          },
 		{ "gid-map",            required_argument, NULL, OPTION_GIDMAP          },
 		{ "nic",                required_argument, NULL, OPTION_NIC             },
+		{ "cgroup",             required_argument, NULL, OPTION_CGROUP          },
 
 		/* Opt-out feature flags */
 		{ "no-fake-devtmpfs",   no_argument, NULL, OPTION_NO_FAKE_DEVTMPFS      },
@@ -406,6 +408,13 @@ int main(int argc, char *argv[], char *envp[])
 
 			case OPTION_GIDMAP:
 				id_map_parse(opts.gid_map, optarg);
+				break;
+
+			case OPTION_CGROUP:
+				if (opts.ncgroups >= MAX_CGROUPS) {
+					errx(1, "can only join a maximum of %d cgroups", MAX_CGROUPS);
+				}
+				opts.cgroups[opts.ncgroups++] = optarg;
 				break;
 
 			case OPTION_NO_FAKE_DEVTMPFS:


### PR DESCRIPTION
This is a WIP. I don't really know yet if this is going to end up being useful, given the privilege model (in particular, I don't know yet if bst should bypass the write check on the parent cgroup.procs file, but time will tell).

I'll leave this unmerged until we can determine if this is useful as-is, or if it needs to be reworked.