### PR TITLE
limits: fix uninitialized value read

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -512,7 +512,10 @@ int enter(struct entry_settings *opts)
 	}
 
 	for (int resource = 0; resource < RLIM_NLIMITS; ++resource) {
-		struct rlimit const * value = opts->limits[resource];
+		struct rlimit const * value = NULL;
+		if (opts->limits[resource].present) {
+			value = &opts->limits[resource].rlim;
+		}
 		/* When no_copy_hard_limits is not set, we always want to call apply_limit, either
 		   with the explicitly configured value (value != NULL), or by copying hard->soft
 		   (value == NULL). */

--- a/enter.h
+++ b/enter.h
@@ -8,6 +8,7 @@
 # define ENTER_H_
 
 # include <limits.h>
+# include <stdbool.h>
 # include <sys/resource.h>
 # include <sys/stat.h>
 # include <time.h>
@@ -17,6 +18,11 @@
 # include "ns.h"
 # include "timens.h"
 # include "userns.h"
+
+struct limit {
+	bool present;
+	struct rlimit rlim;
+};
 
 enum {
 	MAX_MOUNT = 4096,
@@ -62,9 +68,7 @@ struct entry_settings {
 
 	const char *arch;
 
-	// Set the `limits' pointer when the option has been provided.
-	struct rlimit limits_storage[RLIM_NLIMITS];
-	struct rlimit *limits[RLIM_NLIMITS];
+	struct limit limits[RLIM_NLIMITS];
 
 	const char *setup_program;
 	char *const *setup_argv;

--- a/main.c
+++ b/main.c
@@ -150,10 +150,10 @@ static void handle_limit_arg(int option_num, struct entry_settings *opts, char *
 	struct opt const * opt_ent = option_map + index;
 	assert(opt_ent->option_num == option_num);
 
-	if (parse_rlimit(opt_ent->resource, opts->limits_storage + opt_ent->resource, arg)) {
+	if (parse_rlimit(opt_ent->resource, &opts->limits[opt_ent->resource].rlim, arg)) {
 		err(1, "error in --limit-%s value", opt_ent->name);
 	}
-	*(opts->limits + opt_ent->resource) = opts->limits_storage + opt_ent->resource;
+	opts->limits[opt_ent->resource].present = true;
 }
 
 int usage(int error, char *argv0)


### PR DESCRIPTION
The limit parsing logic now always calls getrlimit and only stomps on
the current value if it was actually specified. I also simplified the pointer+limit storage logic in the entry structure, which seems to have made the crashes go away.