### PR TITLE
WIP: cli: add --no-safeguards

### DIFF
--- a/enter.h
+++ b/enter.h
@@ -82,6 +82,7 @@ struct entry_settings {
 	int no_init;
 	int no_loopback_setup;
 	int no_env;
+	int no_safeguards;
 };
 
 int enter(struct entry_settings *opts);

--- a/main.c
+++ b/main.c
@@ -58,6 +58,7 @@ enum {
 	OPTION_NO_INIT,
 	OPTION_NO_ENV,
 	OPTION_NO_COPY_HARD_LIMITS,
+	OPTION_NO_SAFEGUARDS,
 };
 
 static void process_nslist_entry(const char **out, const char *share, const char *path, int append_nsname)
@@ -281,6 +282,7 @@ int main(int argc, char *argv[], char *envp[])
 		{ "no-loopback-setup",   no_argument, NULL, OPTION_NO_LOOPBACK_SETUP    },
 		{ "no-init",             no_argument, NULL, OPTION_NO_INIT              },
 		{ "no-env",              no_argument, NULL, OPTION_NO_ENV               },
+		{ "no-safeguards",       no_argument, NULL, OPTION_NO_SAFEGUARDS        },
 
 		{ 0, 0, 0, 0 }
 	};
@@ -556,6 +558,10 @@ int main(int argc, char *argv[], char *envp[])
 
 			case OPTION_NO_ENV:
 				opts.no_env = 1;
+				break;
+
+			case OPTION_NO_SAFEGUARDS:
+				opts.no_safeguards = 1;
 				break;
 
 			case 'r':

--- a/net.h
+++ b/net.h
@@ -19,6 +19,7 @@ struct ipvlan {
 };
 
 struct nic_options {
+	unsigned idx;
 	char type[16];
 	char name[IF_NAMESIZE];
 	unsigned link_idx;
@@ -31,7 +32,7 @@ struct nic_options {
 
 int init_rtnetlink_socket();
 
-void net_if_add(int sockfd, const struct nic_options *nicopts);
+unsigned net_if_add(int sockfd, const struct nic_options *nicopts);
 void net_if_rename(int sockfd, int link, const char *to);
 void net_if_up(int sockfd, const char *name);
 


### PR DESCRIPTION
This commit adds a new option to allow bst to change existing
namespaces. This in particularly useful to perform any complex setup of
a spacetime via invoking bst multiple times. For instance:

    $ bst --persist=./ns --share pid --mount tmp,/some/root/tmp,tmpfs true
    $ bst --no-safeguards --share=./ns --share pid cp -r /files /some/root/tmp
    $ bst --no-safeguards --share=./ns --root /some/root /bin/sh

... is a viable alternative to using a setup script if performance is
critical.

---

This is a work in progress, and should not be merged yet. There are issues with the way that NIC creation is handled with no safeguards, due to the assumptions that bst makes on the way that interfaces are created & renamed.