### PR TITLE
init: don't put main child into its own process group

### DIFF
--- a/init.c
+++ b/init.c
@@ -39,13 +39,6 @@ int main(int argc, char *argv[], char *envp[])
 	}
 
 	if (!main_child_pid) {
-		if (setpgid(0, 0) == -1) {
-			err(1, "setpgid");
-		}
-		if (tcsetpgrp(STDIN_FILENO, getpgrp()) == -1 && errno != ENOTTY) {
-			err(1, "tcsetpgrp");
-		}
-
 		sigemptyset(&mask);
 		if (sigprocmask(SIG_SETMASK, &mask, NULL) == -1) {
 			err(1, "sigprocmask");
@@ -58,7 +51,7 @@ int main(int argc, char *argv[], char *envp[])
 	for (;;) {
 		siginfo_t info;
 		sig_wait(&mask, &info);
-		sig_forward(&info, -main_child_pid);
+		sig_forward(&info, main_child_pid);
 
 		if (info.si_signo != SIGCHLD) {
 			continue;


### PR DESCRIPTION
We lose the ability to kill the main process subtree, but it's fine
considering that init terminates when it reaps the main child, which
kills the rest of the pid namespace.

This change was motivated by bst rendering processes unkillable if they
were put in the background. `fg` would end up putting bst back in the
background rather than the new process group.