### PR TITLE
init: do not open init program if within root

### DIFF
--- a/path.c
+++ b/path.c
@@ -13,7 +13,7 @@
    * removes duplicate slashes
    * removes . components
    * cancels inner .. components with preceding components */
-static void cleanpath(char *path) {
+void cleanpath(char *path) {
 	if (path[0] == '/') {
 		++path;
 	}

--- a/path.h
+++ b/path.h
@@ -7,6 +7,7 @@
 #ifndef PATH_H_
 # define PATH_H_
 
+void cleanpath(char *path);
 void makepath_r(char *out, char *fmt, ...);
 char *makepath(char *fmt, ...);
 


### PR DESCRIPTION
If the specified init program exists within the target root, we must not
open it before pivoting roots, as doing so is erroneous when the target
init is a symlink.