### PR TITLE
mount: make bst_devtmpfs work on /dev

### DIFF
--- a/path.c
+++ b/path.c
@@ -13,7 +13,7 @@
    * removes duplicate slashes
    * removes . components
    * cancels inner .. components with preceding components */
-static void cleanpath(char *path) {
+void cleanpath(char *path) {
 	if (path[0] == '/') {
 		++path;
 	}

--- a/path.h
+++ b/path.h
@@ -7,6 +7,7 @@
 #ifndef PATH_H_
 # define PATH_H_
 
+void cleanpath(char *path);
 void makepath_r(char *out, char *fmt, ...);
 char *makepath(char *fmt, ...);
 


### PR DESCRIPTION
Previously, bst would give up trying to setup the fake devtmpfs mount if
the target was the host /dev. This was because setting up the fake
devtmpfs involved bind-mounting devices from the original /dev.

This commit makes this problem disappear by preparing said mount on /tmp
if we're trying to mount over the host /dev.