### PR TITLE
Bug fix along with NULL and '\0' corrections

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -49,7 +49,7 @@ static inline size_t append_argv(char **argv, size_t argc, char *arg)
 static void apply_limit(int resource, struct rlimit const *value)
 {
 	struct rlimit new_limit;
-	if (!value) {
+	if (value == NULL) {
 		if (getrlimit(resource, &new_limit)) {
 			if (errno == EINVAL) {
 				/* Skip this limit -- it is not supported. */
@@ -117,7 +117,7 @@ int enter(struct entry_settings *opts)
 	}
 	deny_new_capabilities = 1;
 
-	const char *root = opts->root ? opts->root : "/";
+	const char *root = (opts->root != NULL) ? opts->root : "/";
 
 	char resolved_root[PATH_MAX];
 	if (realpath(root, resolved_root) == NULL) {
@@ -128,7 +128,7 @@ int enter(struct entry_settings *opts)
 
 	char cwd[PATH_MAX];
 	char *workdir = opts->workdir;
-	if ((!workdir || workdir[0] == '\0')) {
+	if ((workdir == NULL || workdir[0] == '\0')) {
 		if (getcwd(cwd, sizeof (cwd)) == NULL) {
 			err(1, "getcwd");
 		}
@@ -149,7 +149,7 @@ int enter(struct entry_settings *opts)
 	}
 	/* Our tentative to use the cwd failed, or it worked and the cwd _is_ the
 	   new root. In both cases, the workdir must be /. */
-	if (!workdir || workdir[0] == '\0') {
+	if (workdir == NULL || workdir[0] == '\0') {
 		workdir = "/";
 	}
 
@@ -180,7 +180,7 @@ int enter(struct entry_settings *opts)
 		err(1, "could not make / private: mount");
 	}
 
-	if (opts->arch && opts->arch[0] != 0) {
+	if (opts->arch != NULL && opts->arch[0] != '\0') {
 		setarch(opts->arch);
 	}
 
@@ -217,7 +217,7 @@ int enter(struct entry_settings *opts)
 	}
 
 	if (pid) {
-		if (opts->pidfile) {
+		if (opts->pidfile != NULL) {
 			int pidfile = open(opts->pidfile, O_WRONLY | O_CREAT | O_CLOEXEC | O_NOCTTY , 0666);
 			if (pidfile == -1) {
 				err(1, "open %s", opts->pidfile);
@@ -340,7 +340,7 @@ int enter(struct entry_settings *opts)
 		}
 	}
 
-	if (opts->setup_program) {
+	if (opts->setup_program != NULL) {
 		pid_t pid = fork();
 		if (pid == -1) {
 			err(1, "setup: fork");
@@ -358,7 +358,7 @@ int enter(struct entry_settings *opts)
 			extern char **environ;
 
 			char *const *argv = default_argv;
-			if (opts->setup_argv) {
+			if (opts->setup_argv != NULL) {
 				argv = opts->setup_argv;
 			}
 
@@ -416,23 +416,23 @@ int enter(struct entry_settings *opts)
 	}
 
 	/* Set the host and domain names only when in an UTS namespace. */
-	if ((opts->hostname || opts->domainname) && !uts_unshare) {
+	if ((opts->hostname != NULL || opts->domainname != NULL ) && !uts_unshare) {
 		errx(1, "attempted to set host or domain names on the host UTS namespace.");
 	}
 
 	const char *hostname = opts->hostname;
-	if (!hostname && uts_unshare) {
+	if (hostname == NULL && uts_unshare) {
 		hostname = "localhost";
 	}
-	if (hostname && sethostname(hostname, strlen(hostname)) == -1) {
+	if (hostname != NULL && sethostname(hostname, strlen(hostname)) == -1) {
 		err(1, "sethostname");
 	}
 
 	const char *domainname = opts->domainname;
-	if (!domainname && uts_unshare) {
+	if (domainname == NULL && uts_unshare) {
 		domainname = "localdomain";
 	}
-	if (domainname && setdomainname(domainname, strlen(domainname)) == -1) {
+	if (domainname != NULL && setdomainname(domainname, strlen(domainname)) == -1) {
 		err(1, "setdomainname");
 	}
 
@@ -588,7 +588,7 @@ int enter(struct entry_settings *opts)
 		argc = append_argv(argv, argc, opts->argv[0]);
 		argc = append_argv(argv, argc, (char *) opts->pathname);
 		char *const *arg = opts->argv + 1;
-		for (; *arg; ++arg) {
+		for (; *arg != NULL; ++arg) {
 			argc = append_argv(argv, argc, *arg);
 		}
 		argv[argc] = NULL;

--- a/main.c
+++ b/main.c
@@ -120,7 +120,7 @@ static void process_share(const char **out, const char *optarg)
 		append_nsname = false;
 	}
 
-	for (; share; share = strtok(NULL, ",")) {
+	for (; share != NULL; share = strtok(NULL, ",")) {
 		process_nslist_entry(out, share, path, append_nsname);
 	}
 }
@@ -136,7 +136,7 @@ static void process_persist(const char **out, const char *optarg)
 	/* Specifying a standalone path means that all namespaces should be persisted
 	   into nsfs files relative to that directory path. */
 	char all_namespaces[] = ALL_NAMESPACES;
-	if (!path) {
+	if (path == NULL) {
 		path = nsnames;
 		nsnames = all_namespaces;
 	}
@@ -148,7 +148,7 @@ static void process_persist(const char **out, const char *optarg)
 	const char *share = strtok(nsnames, ",");
 	bool multiple = share + strlen(share) != nsnames + nsnames_len;
 
-	for (; share; share = strtok(NULL, ",")) {
+	for (; share != NULL; share = strtok(NULL, ",")) {
 		process_nslist_entry(out, share, path, multiple);
 	}
 }
@@ -162,7 +162,7 @@ static void process_unshare(const char **out, char *nsnames)
 		nsnames = all_namespaces;
 	}
 
-	for (const char *ns = strtok(nsnames, ","); ns; ns = strtok(NULL, ",")) {
+	for (const char *ns = strtok(nsnames, ","); ns != NULL; ns = strtok(NULL, ",")) {
 		process_nslist_entry(out, ns, NULL, false);
 	}
 }
@@ -370,7 +370,7 @@ int main(int argc, char *argv[], char *envp[])
 				break;
 
 			case OPTION_GROUPS:
-				for (char *grp = strtok(optarg, ","); grp; grp = strtok(NULL, ",")) {
+				for (char *grp = strtok(optarg, ","); grp != NULL; grp = strtok(NULL, ",")) {
 					if (opts.ngroups >= NGROUPS_MAX) {
 						errx(1, "can only be part of a maximum of %d groups", NGROUPS_MAX);
 					}
@@ -746,7 +746,7 @@ end:
 		++argv0;
 	}
 
-	new_argv[0] = argv0 ? argv0 : argv[optind];
+	new_argv[0] = (argv0 != NULL) ? argv0 : argv[optind];
 	for (int i = 1; i < argc - optind; ++i) {
 		new_argv[i] = argv[optind + i];
 	}
@@ -756,7 +756,7 @@ end:
 	opts.argv = new_argv;
 	opts.envp = newenv;
 
-	if (opts.workdir && opts.workdir[0] != '\0' && opts.workdir[0] != '/') {
+	if (opts.workdir != NULL && opts.workdir[0] != '\0' && opts.workdir[0] != '/') {
 		errx(1, "workdir must be an absolute path.");
 	}
 

--- a/mount.c
+++ b/mount.c
@@ -81,30 +81,30 @@ static void update_mount_flags_and_options(unsigned long *mountflags, char *opts
 		{ "suid",          MS_NOSUID },
 	};
 
-	if (!opts) {
+	if (opts == NULL) {
 		return;
 	}
 
 	char sentinel;
 	char *newopts = opts;
-	for (char *opt = opts, *delim = &sentinel; delim && *opt; opt = delim + 1) {
+	for (char *opt = opts, *delim = &sentinel; delim != NULL && *opt != '\0'; opt = delim + 1) {
 
 		*delim = ',';
 		delim = strchr(opt, ',');
-		if (delim) {
-			*delim = 0;
+		if (delim != NULL) {
+			*delim = '\0';
 		}
 
 		struct mntflag *found;
 
 		found = bsearch(opt, flags, lengthof(flags), sizeof (*flags), cmpflags);
-		if (found) {
+		if (found != NULL) {
 			*mountflags |= found->flag;
 			continue;
 		}
 
 		found = bsearch(opt, neg_flags, lengthof(neg_flags), sizeof (*neg_flags), cmpflags);
-		if (found) {
+		if (found != NULL) {
 			*mountflags &= ~found->flag;
 			continue;
 		}
@@ -112,7 +112,7 @@ static void update_mount_flags_and_options(unsigned long *mountflags, char *opts
 		if (newopts > opts) {
 			*(newopts++) = ',';
 		}
-		for (char *s = opt; *s; ++s, ++newopts) {
+		for (char *s = opt; *s != '\0'; ++s, ++newopts) {
 			*newopts = *s;
 		}
 	}

--- a/path.c
+++ b/path.c
@@ -21,14 +21,14 @@ void cleanpath(char *path) {
 	char *out = path;
 	char *start = path;
 
-	while (*path) {
+	while (*path != '\0') {
 		if (*path == '/') {
 			// empty component
 			++path;
-		} else if (*path == '.' && (!*(path+1) || *(path+1) == '/')) {
+		} else if (*path == '.' && (*(path+1) == '\0' || *(path+1) == '/')) {
 			// . component
 			++path;
-		} else if (*path == '.' && *(path+1) == '.' && (!*(path+2) || *(path+2) == '/')) {
+		} else if (*path == '.' && *(path+1) == '.' && (*(path+2) == '\0' || *(path+2) == '/')) {
 			// .. component
 			path += 2;
 
@@ -44,7 +44,7 @@ void cleanpath(char *path) {
 				*out = '/';
 				++out;
 			}
-			for (; *path && *path != '/'; ++path, ++out) {
+			for (; *path != '\0' && *path != '/'; ++path, ++out) {
 				*out = *path;
 			}
 		}

--- a/path.c
+++ b/path.c
@@ -28,7 +28,7 @@ void cleanpath(char *path) {
 		} else if (*path == '.' && (!*(path+1) || *(path+1) == '/')) {
 			// . component
 			++path;
-		} else if (*path == '.' && *(path+1) == '.' && (!*(path+1) || *(path+1) == '/')) {
+		} else if (*path == '.' && *(path+1) == '.' && (!*(path+2) || *(path+2) == '/')) {
 			// .. component
 			path += 2;
 

--- a/setarch.c
+++ b/setarch.c
@@ -22,8 +22,7 @@ struct exec_domain {
 void setarch(const char *arch)
 {
 	static struct exec_domain domains[] = {
-		/* Placeholder for host execution domain */
-		{ "", 0 },
+		{ "", 0 },			/* Placeholder for host execution domain */
 		{ "linux32", PER_LINUX32 },
 		{ "linux64", PER_LINUX },
 		{ "x86_64",  PER_LINUX },
@@ -31,7 +30,7 @@ void setarch(const char *arch)
 		{ "i486",    PER_LINUX32 },
 		{ "i586",    PER_LINUX32 },
 		{ "i686",    PER_LINUX32 },
-		{ "", 0 }
+		{ "", 0 }			/* Entry to mark end of the list */
 	};
 
 	struct exec_domain *host_domain = &domains[0];
@@ -49,13 +48,13 @@ void setarch(const char *arch)
 #endif
 
 	struct exec_domain *domain = domains;
-	for (; *domain->name; ++domain) {
+	for (; *domain->name != '\0'; ++domain) {
 		if (strncmp(domain->name, arch, MACHINE_SIZE) == 0) {
 			break;
 		}
 	}
 
-	if (!*domain->name) {
+	if (*domain->name == '\0') {
 		errx(1, "setarch: unknown arch %s.", arch);
 	}
 

--- a/setarch.c
+++ b/setarch.c
@@ -22,7 +22,7 @@ struct exec_domain {
 void setarch(const char *arch)
 {
 	static struct exec_domain domains[] = {
-		{ "", 0 },			/* Placeholder for host execution domain */
+		{ "", 0 },                      /* Placeholder for host execution domain */
 		{ "linux32", PER_LINUX32 },
 		{ "linux64", PER_LINUX },
 		{ "x86_64",  PER_LINUX },
@@ -30,7 +30,7 @@ void setarch(const char *arch)
 		{ "i486",    PER_LINUX32 },
 		{ "i586",    PER_LINUX32 },
 		{ "i686",    PER_LINUX32 },
-		{ "", 0 }			/* Entry to mark end of the list */
+		{ "", 0 }                       /* Entry to mark end of the list */
 	};
 
 	struct exec_domain *host_domain = &domains[0];

--- a/unpersist.c
+++ b/unpersist.c
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
 	static struct option options[] = {
 		{ "help",       no_argument,        NULL,   'h' },
 		{ "no-unlink",  no_argument,        NULL,   OPTION_NO_UNLINK },
-		{ 0, 0, 0, 0 }
+		{ NULL, 0, NULL, 0 }
 	};
 
 	static struct {

--- a/userns.c
+++ b/userns.c
@@ -68,7 +68,7 @@ void id_map_parse(id_map map, char *opt)
 	size_t i = 0;
 	char *saveptr;
 	char *rangestr = strtok_r(opt, ",", &saveptr);
-	for (; rangestr; rangestr = strtok_r(NULL, ",", &saveptr)) {
+	for (; rangestr != NULL; rangestr = strtok_r(NULL, ",", &saveptr)) {
 		uint32_t inner = id_parse(strtok(rangestr, ":"), "inner id range start");
 		uint32_t outer = id_parse(strtok(NULL, ":"), "outer id range start");
 		uint32_t length = id_parse(strtok(NULL, ""), "id range length");
@@ -106,7 +106,7 @@ void id_map_load_subids(id_map map, const char *subid_path, const struct id *id)
 	size_t range = id_map_append(map, 0, 0, id->id, 1);
 
 	FILE *subids = fopen(subid_path, "r");
-	if (!subids) {
+	if (subids == NULL) {
 		return;
 	}
 
@@ -121,7 +121,7 @@ void id_map_load_subids(id_map map, const char *subid_path, const struct id *id)
 	   size assumptions tend to bite back, and pages are extremely cheap. */
 	char line[4096];
 
-	while (fgets(line, sizeof (line), subids)) {
+	while (fgets(line, sizeof (line), subids) != NULL) {
 		char entryname[ID_STR_MAX + 1];
 		entryname[ID_STR_MAX] = 0;
 
@@ -220,7 +220,7 @@ void id_map_load_procids(id_map map, const char *procid_path)
 	memset(map, 0, sizeof (id_map));
 
 	char line[4096];
-	while (fgets(line, sizeof (line), subids)) {
+	while (fgets(line, sizeof (line), subids) != NULL) {
 		uint32_t inner, outer, len;
 
 		int items = sscanf(line, "%" PRIu32 "%" PRIu32 "%" PRIu32 "\n", &inner, &outer, &len);
@@ -458,7 +458,7 @@ struct id id_load_user(uid_t uid)
 	struct id id;
 	struct passwd *passwd = getpwuid(uid);
 	id.id = (uint32_t) uid;
-	id.name = passwd ? passwd->pw_name : NULL;
+	id.name = (passwd != NULL) ? passwd->pw_name : NULL;
 	return id;
 }
 
@@ -467,6 +467,6 @@ struct id id_load_group(gid_t gid)
 	struct id id;
 	struct group *group = getgrgid(gid);
 	id.id = (uint32_t) gid;
-	id.name = group ? group->gr_name : NULL;
+	id.name = (group != NULL) ? group->gr_name : NULL;
 	return id;
 }


### PR DESCRIPTION
The first commit fixes a bug in **cleanpath.c** where ".." path entries are not properly detected and, therefore, not collapsed.  I suspect the paths continue to be usable by the program even if they are not ideal which explains why it has not been detected previously.

The second commit adds proper checks for **NULL** and **'\0'**, replacing code that simply checks or assume these values are zero.  This is hygiene and not any change in functionality.  I made the edits simply because I was there, reviewing the code.