### PR TITLE
pty: fix signal delivery

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -275,7 +275,6 @@ int enter(struct entry_settings *opts)
 			
 		for (;;) {
 
-			int waitflags = WEXITED | WNOHANG;
 			siginfo_t info;
 			if (parentSock < 0) {
 				sig_wait(&mask, &info);
@@ -284,7 +283,7 @@ int enter(struct entry_settings *opts)
 					continue;
 				}
 			} else {
-				if (!tty_parent_select(pid, &waitflags)) {
+				if (!tty_parent_select(pid)) {
 					continue;
 				}
 			}
@@ -294,7 +293,7 @@ int enter(struct entry_settings *opts)
 			   exited. */
 
 			int rc;
-			while ((rc = waitid(P_ALL, 0, &info, waitflags)) != -1) {
+			while ((rc = waitid(P_ALL, 0, &info, WEXITED | WNOHANG)) != -1) {
 				if (info.si_signo != SIGCHLD) {
 					break;
 				}

--- a/tty.h
+++ b/tty.h
@@ -12,7 +12,7 @@
 
 void tty_setup_socketpair(int *pParentSock, int *pChildSock);
 void tty_parent_setup(int fd);
-bool tty_parent_select(pid_t pid, int *pwaitflags);
+bool tty_parent_select(pid_t pid);
 void tty_child(int fd);
 
 #endif /* !TTY_H */


### PR DESCRIPTION
We were only getting the first signal since pselect unblocks all
signals after it is called instead of just restoring the mask.

Removed the use of pselect because it was redundant.  We were
already blocking the signals.

Also removed some of the hacks that were in place to work around
missing SIGCHLD.

Finally, added correct setting of the term window size on parent setup.