### PR TITLE
Unify parent wait code using epoll

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -27,6 +27,7 @@
 #include "bst_limits.h"
 #include "capable.h"
 #include "enter.h"
+#include "errutil.h"
 #include "mount.h"
 #include "net.h"
 #include "ns.h"
@@ -373,6 +374,9 @@ int enter(struct entry_settings *opts)
 			}
 		}
 	}
+
+	/* err() and errx() cannot use exit(), since it's not fork-safe. */
+	err_exit = _exit;
 
 	if (parentSock >= 0) {
 		close(parentSock);

--- a/err.c
+++ b/err.c
@@ -1,0 +1,98 @@
+/* Copyright © 2021 Arista Networks, Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the MIT license that can be found
+ * in the LICENSE file.
+ */
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdnoreturn.h>
+#include <string.h>
+#include <unistd.h>
+
+/* The err(3) function family is generally not prepared to deal with error
+   handling after the tty has been changed to raw mode. They do not call
+   atexit handlers and the line endings are not configurable.
+
+   To address this, we reimplement most of these functions here, so that
+   they still behave correctly in our use-cases. */
+
+void (*err_exit)(int) = exit;
+const char *err_line_ending = "\n";
+
+/* fdprintf and vfdprintf are fork-safe versions of fprintf and vfprintf. */
+
+static void vfdprintf(int fd, const char *fmt, va_list vl)
+{
+	char buf[BUFSIZ];
+	int written = vsnprintf(buf, sizeof (buf), fmt, vl);
+	buf[sizeof (buf) - 1] = '\0';
+	if ((size_t) written >= sizeof (buf)) {
+		written = sizeof (buf);
+	}
+	write(fd, buf, (size_t) written);
+}
+
+static void fdprintf(int fd, const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	vfdprintf(fd, fmt, vl);
+	va_end(vl);
+}
+
+extern const char *__progname;
+
+void vwarn(const char *fmt, va_list vl)
+{
+	fdprintf(STDERR_FILENO, "%s: ", __progname);
+	vfdprintf(STDERR_FILENO, fmt, vl);
+	fdprintf(STDERR_FILENO, ": %s%s", strerror(errno), err_line_ending);
+}
+
+void vwarnx(const char *fmt, va_list vl)
+{
+	fdprintf(STDERR_FILENO, "%s: ", __progname);
+	vfdprintf(STDERR_FILENO, fmt, vl);
+	write(STDERR_FILENO, err_line_ending, strlen(err_line_ending));
+}
+
+void warn(const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	vwarn(fmt, vl);
+	va_end(vl);
+}
+
+void warnx(const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	vwarnx(fmt, vl);
+	va_end(vl);
+}
+
+noreturn void err(int eval, const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	vwarn(fmt, vl);
+	va_end(vl);
+
+	err_exit(eval);
+	__builtin_unreachable();
+}
+
+noreturn void errx(int eval, const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	vwarnx(fmt, vl);
+	va_end(vl);
+
+	err_exit(eval);
+	__builtin_unreachable();
+}

--- a/errutil.h
+++ b/errutil.h
@@ -1,0 +1,13 @@
+/* Copyright © 2021 Arista Networks, Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the MIT license that can be found
+ * in the LICENSE file.
+ */
+
+#ifndef ERRUTIL_H_
+# define ERRUTIL_H_
+
+extern void (*err_exit)(int);
+extern const char *err_line_ending;
+
+#endif /* !ERRUTIL_H */

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ bst_sources = [
 	'capable.c',
 	'compat.c',
 	'enter.c',
+	'err.c',
 	'kvlist.c',
 	'main.c',
 	'mount.c',

--- a/sig.c
+++ b/sig.c
@@ -7,7 +7,10 @@
 #include <err.h>
 #include <errno.h>
 #include <stddef.h>
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include "sig.h"
 
@@ -29,5 +32,46 @@ void sig_forward(const siginfo_t *info, pid_t pid)
 	}
 	if (kill(pid, info->si_signo) == -1) {
 		err(1, "kill");
+	}
+}
+
+void sig_read(int sigfd, siginfo_t *info)
+{
+	struct signalfd_siginfo sigfd_info;
+	ssize_t rd = read(sigfd, &sigfd_info, sizeof (sigfd_info));
+	if (rd == -1) {
+		err(1, "read signalfd");
+	}
+
+	if (rd != sizeof(sigfd_info)) {
+		errx(1, "read signalfd: expected reading size %zu, got %zu", sizeof (sigfd_info), (size_t) rd);
+	}
+
+	info->si_signo = (int) sigfd_info.ssi_signo;
+	info->si_code = sigfd_info.ssi_code;
+}
+
+void sig_setup(int epollfd, const sigset_t *set, pid_t helper_pid, epoll_handler_fn *fn)
+{
+	int sigfd = signalfd(-1, set, SFD_CLOEXEC);
+	if (sigfd == -1) {
+		err(1, "signalfd");
+	}
+
+	static struct epoll_handler handler;
+	handler.fn = fn;
+	handler.fd = sigfd;
+	handler.helper_pid = helper_pid;
+	handler.priority = PRIORITY_LAST;
+
+	struct epoll_event event = {
+		.events = EPOLLIN,
+		.data = {
+			.ptr = &handler,
+		},
+	};
+
+	if (epoll_ctl(epollfd, EPOLL_CTL_ADD, sigfd, &event) == -1) {
+		err(1, "epoll_ctl_add signalfd");
 	}
 }

--- a/sig.h
+++ b/sig.h
@@ -7,9 +7,49 @@
 #ifndef SIG_H_
 # define SIG_H_
 
+# include <limits.h>
 # include <signal.h>
+# include <sys/epoll.h>
+
+typedef int epoll_handler_fn(int epollfd, const struct epoll_event *ev, int fd, pid_t pid);
+
+enum io_readiness {
+	READ_READY  = 1,
+	WRITE_READY = 2,
+	HANGUP      = 4,
+};
+
+enum {
+	PRIORITY_FIRST = INT_MIN,
+	PRIORITY_DEFAULT = 0,
+	PRIORITY_LAST = INT_MAX,
+};
+
+# define EPOLL_HANDLER_CONTINUE (-1)
+
+struct epoll_handler {
+	epoll_handler_fn *fn;
+	int fd;
+
+	/* The priority defines the order in which this handler should be run. */
+	int priority;
+
+	/* The peer file descriptor represents the other side of the handler's
+	   file descriptor, e.g. the file descriptor that must be written to
+	   with the data from fd. */
+	int peer_fd;
+
+	/* The ready flag describes whether this handler is read-ready, write-ready,
+	   or both. */
+	enum io_readiness ready;
+
+	/* The outer helper pid. */
+	pid_t helper_pid;
+};
 
 void sig_wait(const sigset_t *set, siginfo_t *info);
 void sig_forward(const siginfo_t *info, pid_t pid);
+void sig_read(int sigfd, siginfo_t *info);
+void sig_setup(int epollfd, const sigset_t *set, pid_t helper_pid, epoll_handler_fn *fn);
 
 #endif /* !SIG_H_ */

--- a/test/tty.t
+++ b/test/tty.t
@@ -16,3 +16,8 @@ Check that redirections still work
 Ensure we send the correct VEOF control character
 
 	$ yes '' | head -c 32768 | timeout 1 bst --tty sh -c 'stty eof ^B && cat' >/dev/null
+
+Ensure that we send VEOF twice in case there is pending input in the pty buffer
+
+	$ echo -n hello | bst --tty cat
+	hellohello

--- a/test/tty.t
+++ b/test/tty.t
@@ -12,3 +12,7 @@ Check that redirections still work
 
 	$ bst --tty echo hello | cat
 	hello
+
+Ensure we send the correct VEOF control character
+
+	$ yes '' | head -c 32768 | timeout 1 bst --tty sh -c 'stty eof ^B && cat' >/dev/null

--- a/test/tty.t
+++ b/test/tty.t
@@ -6,9 +6,9 @@ Allocate a PTY for the spacetime
 
 Check that redirections still work
 
-	$ echo hello | bst --tty --mount devpts,/dev/pts,devpts,mode=620,ptmxmode=666 cat
+	$ echo hello | bst --tty cat
 	hello
 	hello
 
-	$ bst --tty --mount devpts,/dev/pts,devpts,mode=620,ptmxmode=666 echo hello | cat
+	$ bst --tty echo hello | cat
 	hello

--- a/test/tty.t
+++ b/test/tty.t
@@ -3,3 +3,12 @@
 Allocate a PTY for the spacetime
 	$ bst --tty --mount devpts,/dev/pts,devpts,mode=620,ptmxmode=666 tty
 	/dev/pts/0
+
+Check that redirections still work
+
+	$ echo hello | bst --tty --mount devpts,/dev/pts,devpts,mode=620,ptmxmode=666 cat
+	hello
+	hello
+
+	$ bst --tty --mount devpts,/dev/pts,devpts,mode=620,ptmxmode=666 echo hello | cat
+	hello

--- a/tty.c
+++ b/tty.c
@@ -25,7 +25,8 @@
 #include "sig.h"
 #include "tty.h"
 
-void recv_fd(int socket, int *pFd) {
+void recv_fd(int socket, int *pFd)
+{
 	char buf[1];
 	struct iovec iov[1] = {
 		[0] = {.iov_base = buf, .iov_len = 1 }
@@ -62,7 +63,8 @@ void recv_fd(int socket, int *pFd) {
 	}
 }
 
-void send_fd(int socket, int fd) {
+void send_fd(int socket, int fd)
+{
 	char buf[1] = {0};
 	struct iovec iov[1] = {
 		[0] = {.iov_base = buf, .iov_len = 1 }
@@ -103,7 +105,8 @@ static struct tty_parent_info_s {
 	.termfd = -1,
 };
 
-void tty_setup_socketpair(int *pParentSock, int *pChildSock) {
+void tty_setup_socketpair(int *pParentSock, int *pChildSock)
+{
 	int socks[2];
 	if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, socks) < 0) {
 		err(1, "tty_setup: socketpair");
@@ -187,7 +190,8 @@ static void set_nonblock(int fd, int nonblock)
 	}
 }
 
-void tty_parent_cleanup() {
+void tty_parent_cleanup(void)
+{
 	if (info.termfd >= 0) {
 		/* Drain any remaining data in the terminal buffer */
 		set_nonblock(STDOUT_FILENO, 0);
@@ -209,7 +213,8 @@ void tty_parent_cleanup() {
 	}
 }
 
-void tty_set_winsize() {
+void tty_set_winsize(void)
+{
 	struct winsize wsize;
 	if (info.stdinIsatty) {
 		if (ioctl(STDIN_FILENO, TIOCGWINSZ, (char*) &wsize) < 0) {
@@ -428,7 +433,8 @@ void tty_parent_setup(int epollfd, int socket)
 	}
 }
 
-void tty_child(int socket) {
+void tty_child(int socket)
+{
 	int mfd = open("/dev/pts/ptmx", O_RDWR | O_NONBLOCK);
 	if (mfd < 0) {
 		err(1, "tty_child: open ptmx");

--- a/tty.c
+++ b/tty.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <util.h>
 
+#include "errutil.h"
 #include "sig.h"
 #include "tty.h"
 
@@ -356,7 +357,12 @@ void tty_parent_setup(int epollfd, int socket)
 		if (tcsetattr(STDIN_FILENO, TCSANOW, &tios) == -1) {
 			err(1, "tty_parent: tcsetattr");
 		}
+
+		/* We changed the terminal to raw mode. Line-endings now need carriage
+		   returns in order to be palatable. */
+		err_line_ending = "\r\n";
 	}
+	atexit(tty_parent_cleanup);
 
 	// Wait for the child to create the pty pair and pass the master back.
 	recv_fd(socket, &info.termfd);

--- a/tty.h
+++ b/tty.h
@@ -13,7 +13,7 @@
 void tty_setup_socketpair(int *pParentSock, int *pChildSock);
 void tty_parent_setup(int epollfd, int socket);
 bool tty_parent_select(pid_t pid);
-void tty_parent_cleanup();
+void tty_parent_cleanup(void);
 void tty_child(int fd);
 
 #endif /* !TTY_H */

--- a/tty.h
+++ b/tty.h
@@ -11,8 +11,9 @@
 # include <stdbool.h>
 
 void tty_setup_socketpair(int *pParentSock, int *pChildSock);
-void tty_parent_setup(int fd);
+void tty_parent_setup(int epollfd, int socket);
 bool tty_parent_select(pid_t pid);
+void tty_parent_cleanup();
 void tty_child(int fd);
 
 #endif /* !TTY_H */


### PR DESCRIPTION
These commits move away from select and sigwaitinfo, and collapses the two alternate wait code paths into one using epoll. It also fixes some minute issues with the way that we handle errors when the tty is in raw mode.