### PR TITLE
enter: drop all privileges in wait loop

### DIFF
--- a/capable.c
+++ b/capable.c
@@ -68,3 +68,11 @@ void reset_capabilities(void)
 	}
 	memcpy(current, original, sizeof (current));
 }
+
+void drop_capabilities(void)
+{
+	memset(current, 0, sizeof (current));
+	if (bst_capset(&hdr, current) == -1) {
+		err(1, "capset");
+	}
+}

--- a/capable.h
+++ b/capable.h
@@ -27,5 +27,6 @@ void init_capabilities(void);
 bool capable(uint64_t cap);
 void make_capable(uint64_t cap);
 void reset_capabilities(void);
+void drop_capabilities(void);
 
 #endif /* !CAPABLE_H_ */

--- a/enter.c
+++ b/enter.c
@@ -283,6 +283,18 @@ int enter(struct entry_settings *opts)
 	}
 
 	if (pid) {
+
+		/* Past this point, drop all capabilities. This promises that we do not
+		   need to make any privileged adjustments past initialization, and
+		   makes us debuggable unprivileged during the wait loop. */
+
+		drop_capabilities();
+
+		if (prctl(PR_SET_DUMPABLE, 1) == -1) {
+			/* Not being debuggable is not the end of the world */
+			warn("prctl PR_SET_DUMPABLE");
+		}
+
 		if (childSock >= 0) {
 			close(childSock);
 		}


### PR DESCRIPTION
... and make the process dumpable. This allows unprivileged users to
debug and strace bst when it's past the initialization phase, without
the use of sudo.