### PR TITLE
build: restrict building bst for only linux platforms

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,13 @@ sh    = find_program('sh')
 git   = find_program('git', required: false)
 scdoc = find_program('scdoc', required: get_option('man-pages'))
 
+supported_oses = ['linux']
+targetos = host_machine.system()
+
+if not supported_oses.contains(targetos)
+	error('bst is not supported on ' + targetos + ' platform.')
+endif
+
 # Get the right version
 
 is_git_repo = run_command(['[', '-d', '.git', ']']).returncode() == 0


### PR DESCRIPTION
Currently bst cannot build or run on platforms other than linux. Headers like
prctl.h, linux/capability.h etc are only available on Linux and not on other
platforms. Hence, the meson build process should check the target platform (the
platform for which the binary is being built) and bail out for non-supported
platforms. For example, when trying to build bst on my Mac's darwin platform, I
get the following descriptive error with this change:

Running test binary command: /Users/ani/workspace/bst/build/meson-private/sanitycheckc.exe
C compiler for the build machine: cc (clang 12.0.5 "Apple clang version 12.0.5 (clang-1205.0.22.11)")
C linker for the build machine: cc ld64 650.9
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: x86_64
Host machine cpu: x86_64
Target machine cpu family: x86_64
Target machine cpu: x86_64
Program sh found: YES (/bin/sh)
Program git found: YES (/usr/bin/git)
Program scdoc found: NO

meson.build:19:1: ERROR: Problem encountered: bst is not supported on darwin platform.

Signed-off-by: Ani Sinha <ani@anisinha.ca>