### PR TITLE
cram: add documentation for the -p option

### DIFF
--- a/test/cram.sh
+++ b/test/cram.sh
@@ -10,6 +10,13 @@ usage() {
 	If the directory is not specified, the current work directory is used
 	instead.
 
+	The options are as follows:
+	  -p/--patch  If there is a difference between the expeted output and the
+	              actual output, the expected output in the file will be patched
+	              by the actual output. Setting the environment variable
+	              'CRAM_PATCH' has the same effect. The environment variable
+	              can be used when passing command line option is not possible.
+
 	The file format understood by $0 is a subset of the format used by cram
 	or the glib test suite.
 


### PR DESCRIPTION
Document the '-p'/'--patch' option in the help string. 

Signed-off-by: Ani Sinha <ani@anisinha.ca>