### PR TITLE
mount: properly recursively remount read-only

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -12,4 +12,6 @@
 # define LIBEXECDIR "@libexecdir@"
 # define VERSION "@version@"
 
+#mesondefine HAVE_SYS_mount_setattr
+
 #endif /* !CONFIG_H_ */

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,8 @@ config.set('bindir', bindir)
 config.set('libexecdir', libexecdir)
 config.set('version', version)
 
+config.set('HAVE_SYS_mount_setattr', cc.has_header_symbol('syscall.h', 'SYS_mount_setattr'))
+
 configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
 
 bst_init_sources = [


### PR DESCRIPTION
Historically, recursive read-only remounts of bind-mounts would only turn the top-level mount read-only. This is not a very good default, however, as it tend to surprise people.

Linux 5.12 has given us the means to do so via a new mount_setattr system call. This system call allows the caller to change properties of any given mount, and the combination of AT_RECURSIVE with MOUNT_ATTR_RDONLY has the previously described effect of going through all entries of the mount table recursively, and making them read-only.