### PR TITLE
outer_helper_spawn: fail pid burn silently when all limits are non-critical

### DIFF
--- a/outer.c
+++ b/outer.c
@@ -410,7 +410,14 @@ void outer_helper_spawn(struct outer_helper *helper)
 
 		// Add bst subprocess to cgroup
 		if (burn(subcgroupfd, "cgroup.procs", pidstr) == -1) {
-			err(1, "outer_helper: burn process into cgroup.procs");
+			if (critical_limits > 0) {
+				err(1, "outer_helper: burn process into cgroup.procs");
+			} else {
+				reset_capabilities();
+				close(cgroupfd);
+				close(subcgroupfd);
+				goto unshare;
+			}
 		}
 
 		close(subcgroupfd);


### PR DESCRIPTION
When running in an environment with legacy cgroups, the cgroups-related parts of `outer_helper_spawn` aren't applicable. When a user invokes bst with `--try-limit`, the code needs to fail softly, as if no limit had been specified at all. We handle other cases of this earlier on the code, but we may (apparently) reach as far as burning the child pid into `cgroup.procs` before legacy cgroups balks, so we add another soft-failure for that case here.