### PR TITLE
sig: make PDEATHSIG handling non-racy

### DIFF
--- a/sig.h
+++ b/sig.h
@@ -51,5 +51,6 @@ void sig_wait(const sigset_t *set, siginfo_t *info);
 void sig_forward(const siginfo_t *info, pid_t pid);
 void sig_read(int sigfd, siginfo_t *info);
 void sig_setup(int epollfd, const sigset_t *set, pid_t helper_pid, epoll_handler_fn *fn);
+void sig_setpdeathsig(int signo, pid_t expected_ppid);
 
 #endif /* !SIG_H_ */


### PR DESCRIPTION
The way we've used PDEATHSIG so far was to call it in the child immediately after fork(). This is however inherently racy, because it is absolutely possible for the parent to get SIGKILL'ed after the fork, but before the child gets to call prctl.

This fixes the race by introducing a new function, sig_setpdeathsig.

The function takes the kill signal to pass to prctl PR_SET_PDEATHSIG, as well as the expected parent pid. The way to use this function is as follows:

    pid_t ppid = getpid();
    pid_t pid = fork();
    if (pid == -1) {
        err(1, "fork");
    }
    if (!pid) {
        // in the child
        sig_setpdeathsig(SIGKILL, ppid);
    }

sig_setpdeathsig then takes care of calling prctl(PR_SET_PDEATHSIG, signo), and checks whether the current ppid is the same as the original ppid. If it isn't, it means the parent died and the child got reparented to the nearest subreaper, and the function calls raise(signo).