### PR TITLE
cgroup_helper shan't hold socket for outer_helper process

### DIFF
--- a/outer.c
+++ b/outer.c
@@ -435,6 +435,7 @@ void outer_helper_spawn(struct outer_helper *helper)
 		/* This process is intentionally left to leak as the bst root process must have exited
 			 and thus been removed from bst's cgroup.procs for the cgroup hierarchy to be removed */
 		if (pid == 0) {
+			close(fdpair[SOCKET_CHILD]);
 			cgroup_helper(cgroupfd, child_pid);
 			_exit(0);
 		}


### PR DESCRIPTION
Here's a little tree of processes:

```
  main
    |
    +-(fork:outer_helper) writes uid/gid for child process
    |                     then notifies main that it's done by
    |                     writing to a socketpair
    +-(fork:cgroup_helper) waits for all sibling processes to
    |                     terminate then cleans up the cgroup
```

main waits for outer_helper to do some setup and then outer_helper notifies main that it's done by writing an `ok` to a socketpair. If outer_helper dies before it gets a chance to write the `ok` message, that should be fine - `main`'s end of the socketpair will close when all the references to the other side of the pair close. This normally happens as soon as outer_helper terminates because he as the only copy.

However, cgroup_helper also has a copy of that fd. It doesn't need it, so we should just close it as soon as that process starts.