### PR TITLE
Revisit cgroup support and make it more turnkey

### DIFF
--- a/cgroup.c
+++ b/cgroup.c
@@ -9,14 +9,21 @@
 #include <unistd.h>
 
 #include "cgroup.h"
+#include "config.h"
 #include "fd.h"
 #include "path.h"
 #include "util.h"
 
 extern const struct cgroup_driver_funcs cgroup_driver_native;
+#ifdef HAVE_SYSTEMD
+extern const struct cgroup_driver_funcs cgroup_driver_systemd;
+#endif
 
 static const struct cgroup_driver_funcs *cgroup_drivers[] = {
 	[CGROUP_DRIVER_NATIVE] = &cgroup_driver_native,
+#ifdef HAVE_SYSTEMD
+	[CGROUP_DRIVER_SYSTEMD] = &cgroup_driver_systemd,
+#endif
 };
 
 static enum cgroup_driver cgroup_detected_driver = -1;
@@ -33,6 +40,9 @@ int cgroup_driver_init(enum cgroup_driver driver, bool fatal)
 	}
 
 	static enum cgroup_driver attempts[] = {
+#ifdef HAVE_SYSTEMD
+		CGROUP_DRIVER_SYSTEMD,
+#endif
 		CGROUP_DRIVER_NATIVE,
 	};
 

--- a/cgroup.c
+++ b/cgroup.c
@@ -1,0 +1,225 @@
+#include <err.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+#include "cgroup.h"
+#include "fd.h"
+#include "path.h"
+#include "util.h"
+
+extern const struct cgroup_driver_funcs cgroup_driver_native;
+
+static const struct cgroup_driver_funcs *cgroup_drivers[] = {
+	[CGROUP_DRIVER_NATIVE] = &cgroup_driver_native,
+};
+
+static enum cgroup_driver cgroup_detected_driver = -1;
+
+int cgroup_driver_init(enum cgroup_driver driver, bool fatal)
+{
+	cgroup_detected_driver = driver;
+
+	if (cgroup_detected_driver != (enum cgroup_driver)-1) {
+		if (cgroup_detected_driver < 0 || cgroup_detected_driver >= lengthof(cgroup_drivers)) {
+			errx(1, "unknown cgroup driver ID %d", cgroup_detected_driver);
+		}
+		return cgroup_drivers[cgroup_detected_driver]->init(fatal);
+	}
+
+	static enum cgroup_driver attempts[] = {
+		CGROUP_DRIVER_NATIVE,
+	};
+
+	for (size_t i = 0; i < lengthof(attempts); i++) {
+		if (attempts[i] < 0 || attempts[i] >= lengthof(cgroup_drivers)) {
+			errx(1, "cgroup_driver_init: programming error: unexpected cgroup driver ID %d", cgroup_detected_driver);
+		}
+		if (cgroup_drivers[attempts[i]]->init(false) >= 0) {
+			cgroup_detected_driver = attempts[i];
+			return 0;
+		}
+	}
+	if (fatal) {
+		errx(1, "cgroup_driver_init: no cgroup driver initialized successfully");
+	}
+	return -1;
+}
+
+int cgroup_join(const char *parent, const char *name)
+{
+	return cgroup_drivers[cgroup_detected_driver]->join_cgroup(parent, name);
+}
+
+bool cgroup_current_path(char *path)
+{
+	return cgroup_drivers[cgroup_detected_driver]->current_path(path);
+}
+
+bool cgroup_read_current(char *path)
+{
+	FILE *selfcgroupfd = fopen("/proc/self/cgroup", "r");
+	if (selfcgroupfd == NULL) {
+		err(1, "unable to derive current cgroup hierarchy from /proc/self/cgroup");
+	}
+
+	const char *selfcgroup = NULL;
+	char line[BUFSIZ];
+	while (fgets(line, sizeof (line), selfcgroupfd) != NULL) {
+		if (strncmp(line, "0::/", sizeof ("0::/") - 1) == 0) {
+			// Remove newline character read by fgets
+			line[strcspn(line, "\n")] = '\0';
+			selfcgroup = line + 3;
+			break;
+		}
+	}
+	fclose(selfcgroupfd);
+
+	if (selfcgroup != NULL && path != NULL) {
+		makepath_r(path, "/sys/fs/cgroup/%s", selfcgroup);
+	}
+	return selfcgroup != NULL;
+}
+
+static int rm_cgroup(const char *fpath, const struct stat *sb, int tflag, struct FTW *ftwbuf)
+{
+	char path[PATH_MAX];
+	strncpy(path, fpath, sizeof (path));
+
+	if (tflag == FTW_D) {
+		for (int level = ftwbuf->level; level >= 0; level--) {
+			if (rmdir(path) == -1) {
+				break;
+			}
+			dirname(path);
+		}
+	}
+	return 0;
+}
+
+/* If bst has entered a cgroup this function will epoll the cgroup.events file
+   to detect when all pids have exited the cgroup ("populated 0"). The cgroup is
+   destroyed when this condition is met. */
+static void run_cleaner_child(int cgroupfd, int parentfd, const char *name)
+{
+	char fdpath[PATH_MAX];
+	makepath_r(fdpath, "/proc/self/fd/%d", cgroupfd);
+
+	char cgroup_path[PATH_MAX];
+	if (readlink(fdpath, cgroup_path, sizeof (cgroup_path)) == -1) {
+		err(1, "cgroup_run_cleaner: readlink");
+	}
+
+	int eventfd = openat(cgroupfd, "cgroup.events", 0);
+	if (eventfd == -1) {
+		err(1, "unable to open cgroup.events");
+	}
+
+	struct epoll_event event = {
+		.events = EPOLLET,
+	};
+
+	int epollfd = epoll_create1(0);
+	if (epollfd == -1) {
+		err(1, "epoll_create1");
+	}
+
+	if (epoll_ctl(epollfd, EPOLL_CTL_ADD, eventfd, &event) == -1) {
+		err(1, "epoll_ctl_add cgroupfd");
+	}
+
+	/* The first event is the initial state of the file; skip it, because
+	   at that point the cgroup is still empty, and we'll have populated 0 */
+	epoll_wait(epollfd, &event, 1, -1);
+
+	FILE *eventsfp = fdopen(eventfd, "r");
+	if (eventsfp == NULL) {
+		err(1, "unable to open file pointer to cgroup.events");
+	}
+
+	char populated[BUFSIZ];
+	for (;;) {
+		int ready = epoll_wait(epollfd, &event, 1, -1);
+		if (ready == -1) {
+			err(1, "epoll_wait cgroup.events");
+		}
+
+		rewind(eventsfp);
+
+		/* The order of elements in cgroup.events is not necessarily specified. */
+		while (fgets(populated, BUFSIZ, eventsfp) != NULL) {
+			if (strnlen(populated, sizeof(populated)) == sizeof(populated)) {
+				err(1, "exceeded cgroup.events line read buffer");
+			}
+			if (strncmp(populated, "populated 0", 11) == 0) {
+				nftw(cgroup_path, rm_cgroup, 128, 0);
+
+				/* Let the process exit; no need to clean up fds */
+				return;
+			}
+		}
+	}
+}
+
+void cgroup_run_cleaner(int cgroupfd, int parentfd, const char *name)
+{
+	pid_t pid = fork();
+	if (pid == -1) {
+		err(1, "cgroup_run_cleaner: fork");
+	}
+
+	/* This process is intentionally left to leak as the bst root process must have exited
+		 and thus been removed from bst's cgroup.procs for the cgroup hierarchy to be removed */
+	if (pid == 0) {
+		/* Create a new session in case current group leader is killed */
+		if (setsid() == -1) {
+			err(1, "unable to create new session leader for cgroup cleanup process");
+		}
+
+		/* Make sure all file descriptors except for the ones we're actually using
+		   get closed. This avoids keeping around file descriptors on which
+		   the parent process might be waiting on. */
+		rebind_fds_and_close_rest(3, &cgroupfd, &parentfd, NULL);
+		run_cleaner_child(cgroupfd, parentfd, name);
+		_exit(0);
+	}
+}
+
+void cgroup_enable_controllers(int cgroupfd)
+{
+	char controllers[BUFSIZ];
+	int cfd = openat(cgroupfd, "cgroup.controllers", O_RDONLY, 0);
+	if (cfd == -1) {
+		err(1, "cgroup_enable_controllers: open cgroup.controllers");
+	}
+	if (read(cfd, controllers, sizeof (controllers)) == sizeof (controllers)) {
+		errx(1, "cgroup_enable_controllers: read cgroup.controllers: too many controllers");
+	}
+	if (close(cfd) == -1) {
+		err(1, "cgroup_enable_controllers: close cgroup.controllers");
+	}
+
+	int scfd = openat(cgroupfd, "cgroup.subtree_control", O_WRONLY, 0);
+	if (scfd == -1) {
+		err(1, "cgroup_enable_controllers: open cgroup.subtree_control");
+	}
+
+	char buf[BUFSIZ];
+	buf[0] = '+';
+
+	for (char *controller = strtok(controllers, " "); controller != NULL; controller = strtok(NULL, " ")) {
+		char *last = stpncpy(buf + 1, controller, sizeof (buf) - 1);
+		size_t len = last - buf;
+		if (write(scfd, buf, len) == (ssize_t)-1) {
+			err(1, "cgroup_enable_controllers: write %s into cgroup.subtree_control", buf);
+		}
+	}
+	if (close(scfd) == -1) {
+		err(1, "cgroup_enable_controllers: close cgroup.subtree_control");
+	}
+}

--- a/cgroup.h
+++ b/cgroup.h
@@ -1,0 +1,23 @@
+#ifndef CGROUP_H_
+# define CGROUP_H_
+
+# include <stdbool.h>
+
+struct cgroup_driver_funcs {
+    int (*init)(bool fatal);
+    int (*join_cgroup)(const char *parent, const char *name);
+    bool (*current_path)(char *out);
+};
+
+enum cgroup_driver {
+    CGROUP_DRIVER_NATIVE,
+};
+
+int cgroup_driver_init(enum cgroup_driver driver, bool fatal);
+bool cgroup_current_path(char *path);
+int cgroup_join(const char *parent, const char *name);
+bool cgroup_read_current(char *path);
+void cgroup_enable_controllers(int cgroupfd);
+void cgroup_run_cleaner(int cgroupfd, int parentfd, const char *name);
+
+#endif /* !CGROUP_H_ */

--- a/cgroup.h
+++ b/cgroup.h
@@ -11,6 +11,7 @@ struct cgroup_driver_funcs {
 
 enum cgroup_driver {
     CGROUP_DRIVER_NATIVE,
+    CGROUP_DRIVER_SYSTEMD,
 };
 
 int cgroup_driver_init(enum cgroup_driver driver, bool fatal);

--- a/cgroup_native.c
+++ b/cgroup_native.c
@@ -1,0 +1,90 @@
+#include <err.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "capable.h"
+#include "cgroup.h"
+#include "path.h"
+
+static int cgroup_native_driver_init(bool fatal)
+{
+	/* The native driver can only work with cgroup v2. Perform some sanity
+	   checks to verify this. */
+	if (!cgroup_read_current(NULL)) {
+		return -1;
+	}
+	if (access("/sys/fs/cgroup/cgroup.controllers", F_OK) == -1) {
+		return -1;
+	}
+	return 0;
+}
+
+static bool cgroup_native_current_path(char *path)
+{
+	return cgroup_read_current(path);
+}
+
+static int cgroup_native_join_cgroup(const char *parent, const char *name)
+{
+	int parentfd = open(parent, O_RDONLY | O_DIRECTORY, 0);
+	if (parentfd == -1) {
+		err(1, "cgroup_native_join_cgroup: open %s", parent);
+	}
+
+	if (mkdirat(parentfd, name, 0777) == -1) {
+		err(1, "cgroup_native_join_cgroup: mkdir %s under %s", name, parent);
+	}
+
+	int cgroupfd = openat(parentfd, name, O_RDONLY | O_DIRECTORY, 0);
+	if (cgroupfd == -1) {
+		warn("cgroup_native_join_cgroup: open %s under %s", name, parent);
+		goto unlink;
+	}
+
+	make_capable(BST_CAP_DAC_OVERRIDE);
+	int procs = openat(cgroupfd, "cgroup.procs", O_WRONLY, 0);
+	reset_capabilities();
+
+	if (procs == -1) {
+		warn("cgroup_native_join_cgroup: open cgroup.procs under %s", parent);
+		goto unlink;
+	}
+
+	/* openat was done with full privileges, but we actually just need the ability
+	   to write to cgroups we own */
+	if (faccessat(cgroupfd, "cgroup.procs", W_OK, 0) == -1) {
+		warn("cgroup_native_join_cgroup: access cgroup.procs under %s", parent);
+		goto unlink;
+	}
+
+	/* Start cleaner daemon; it will remove the cgroup once this process dies. */
+	cgroup_run_cleaner(cgroupfd, parentfd, name);
+
+	if (write(procs, "0", 1) == (ssize_t)-1) {
+		warn("cgroup_native_join_cgroup: write cgroup.procs");
+		goto unlink;
+	}
+
+	if (close(procs) == -1) {
+		err(1, "cgroup_native_join_cgroup: close cgroup.procs under %s", parent);
+	}
+	if (close(parentfd) == -1) {
+		err(1, "cgroup_native_join_cgroup: close %s", parent);
+	}
+
+	return cgroupfd;
+
+unlink:
+	if (unlinkat(parentfd, name, AT_REMOVEDIR) == -1) {
+		warn("cgroup_native_join_cgroup: unlink %s under %s", name, parent);
+	}
+	exit(1);
+}
+
+const struct cgroup_driver_funcs cgroup_driver_native = {
+	.init         = cgroup_native_driver_init,
+	.join_cgroup  = cgroup_native_join_cgroup,
+	.current_path = cgroup_native_current_path,
+};

--- a/cgroup_systemd.c
+++ b/cgroup_systemd.c
@@ -1,0 +1,325 @@
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+#include <dbus/dbus.h>
+
+#include "capable.h"
+#include "cgroup.h"
+#include "path.h"
+
+#define BUS_NAME  "org.freedesktop.systemd1"
+#define PATH      "/org/freedesktop/systemd1"
+#define INTERFACE "org.freedesktop.systemd1.Manager"
+
+/* This cgroup driver implements the "Integration is good :)" path of the systemd
+   cgroup delegation guide[1]. It is assumed that readers of this code will
+   have read the guide beforehand.
+
+   The driver talks to systemd via dbus to create a scope in which the bst
+   process will be placed. bst will then move itself into a subcgroup to avoid
+   the no-internal-process rule, and place the child process into a separate
+   subcgroup in which limits will be applied.
+
+   [1]: https://systemd.io/CGROUP_DELEGATION/
+ */
+
+static DBusError dberr;
+static DBusConnection* bus;
+
+static int cgroup_systemd_driver_init(bool fatal)
+{
+	dbus_error_init(&dberr);
+
+	/* Open the system bus if we're root, and the session bus otherwise. This
+	   matches the behaviour of other systemd clients. */
+	if (getuid() == 0) {
+		bus = dbus_bus_get(DBUS_BUS_SYSTEM, &dberr);
+	} else {
+		bus = dbus_bus_get(DBUS_BUS_SESSION, &dberr);
+	}
+	if (dbus_error_is_set(&dberr)) {
+		if (fatal) {
+			errx(1, "cgroup_systemd_driver_init: dbus_connection_open: %s", dberr.message);
+		}
+		return -1;
+	}
+
+	return 0;
+}
+
+static bool cgroup_systemd_current_path(char *path)
+{
+	/* We use machines-bst.slice as default; this corresponds to the
+	   cgroup /machines.slice/machines-bst.slice when the bus is the
+	   system bus, while this corresponds to the user session slice,
+	   i.e. /user.slice/user-<UID>.slice/user-<UID>-machines.slice/user-
+	   <UID>-machines-bst.slice, when the user bus is used. */
+	strcpy(path, "machines-bst.slice");
+	return true;
+}
+
+static size_t bus_copy_type(char *buf, size_t sz, char until, bool once, const char *type)
+{
+	size_t idx = 0;
+	while (idx < sz - 1 && type[idx]) {
+		char t = type[idx];
+		buf[idx] = type[idx];
+		idx++;
+
+		if (t == until) {
+			break;
+		}
+		switch (t) {
+		case DBUS_STRUCT_BEGIN_CHAR:
+			idx += bus_copy_type(buf + idx, sz - idx, DBUS_STRUCT_END_CHAR, false, type + idx);
+			buf[idx] = type[idx];
+			idx++;
+		}
+		if (once) {
+			break;
+		}
+	}
+	buf[idx] = 0;
+	return idx;
+}
+
+static bool bus_message_append_aux(DBusMessageIter *iter, const char **fmt, char until, bool once, va_list vl)
+{
+	char typebuf[128];
+
+	DBusMessageIter container;
+	for (; **fmt != until; ++(*fmt)) {
+		switch (**fmt) {
+		case DBUS_TYPE_STRING:
+			{
+				char *s = va_arg(vl, char *);
+				if (!dbus_message_iter_append_basic(iter, **fmt, &s)) {
+					return false;
+				}
+			} break;
+		case DBUS_TYPE_UINT32:
+			{
+				uint32_t u = va_arg(vl, uint32_t);
+				if (!dbus_message_iter_append_basic(iter, **fmt, &u)) {
+					return false;
+				}
+			} break;
+		case DBUS_TYPE_BOOLEAN:
+			{
+				dbus_bool_t b = va_arg(vl, int);
+				if (!dbus_message_iter_append_basic(iter, **fmt, &b)) {
+					return false;
+				}
+			} break;
+		case DBUS_TYPE_VARIANT:
+			{
+				const char *type = va_arg(vl, const char *);
+				if (!dbus_message_iter_open_container(iter, **fmt, type, &container)) {
+					return false;
+				}
+				if (!bus_message_append_aux(&container, &type, '\0', true, vl)) {
+					return false;
+				}
+				if (!dbus_message_iter_close_container(iter, &container)) {
+					return false;
+				}
+			} break;
+		case DBUS_TYPE_ARRAY:
+			{
+				int len = va_arg(vl, int);
+				size_t typesz = bus_copy_type(typebuf, sizeof (typebuf), '\0', true, *fmt+1);
+
+				if (!dbus_message_iter_open_container(iter, **fmt, typebuf, &container)) {
+					return false;
+				}
+				*fmt += typesz - 1;
+
+				for (int i = 0; i < len; i++) {
+					const char *type = typebuf;
+					if (!bus_message_append_aux(&container, &type, '\0', true, vl)) {
+						return false;
+					}
+				}
+				if (!dbus_message_iter_close_container(iter, &container)) {
+					return false;
+				}
+
+			} break;
+		case DBUS_STRUCT_BEGIN_CHAR:
+			{
+				bus_copy_type(typebuf, sizeof (typebuf), DBUS_STRUCT_END_CHAR, false, *fmt+1);
+				if (!dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &container)) {
+					return false;
+				}
+				++(*fmt);
+				if (!bus_message_append_aux(&container, fmt, DBUS_STRUCT_END_CHAR, false, vl)) {
+					return false;
+				}
+				if (!dbus_message_iter_close_container(iter, &container)) {
+					return false;
+				}
+			} break;
+		default:
+			errx(1, "programming error: unsupported D-Bus type '%c'", **fmt);
+		}
+		if (once) {
+			break;
+		}
+	}
+	return true;
+}
+
+static bool bus_message_append(DBusMessageIter *iter, const char *fmt, ...)
+{
+	va_list vl;
+	va_start(vl, fmt);
+	bool ok = bus_message_append_aux(iter, &fmt, '\0', false, vl);
+	va_end(vl);
+	return ok;
+}
+
+static int cgroup_systemd_join_cgroup(const char *parent, const char *name)
+{
+	/* Register a signal to wait for the scope creation to complete */
+
+	DBusError error;
+	dbus_error_init(&error);
+	const char *expr = "type='signal',"
+			"sender='"BUS_NAME"',"
+			"path='"PATH"',"
+			"interface='"INTERFACE"',"
+			"member='JobRemoved'";
+	dbus_bus_add_match(bus, expr, &error);
+	dbus_connection_flush(bus);
+	if (dbus_error_is_set(&error)) {
+		errx(1, "cgroup_systemd_join_cgroup: dbus_bus_add_match: %s", error.message);
+	}
+
+	/* Create a transient scope unit in which the current process will be
+	   placed. */
+	DBusMessage *msg = dbus_message_new_method_call(BUS_NAME, PATH, INTERFACE, "StartTransientUnit");
+	if (!msg) {
+		errno = ENOMEM;
+		err(1, "cgroup_systemd_join_cgroup: dbus_message_new_method_call");
+	}
+
+	char namebuf[PATH_MAX];
+	makepath_r(namebuf, "%s.scope", name);
+
+	DBusMessageIter iter, props;
+	dbus_message_iter_init_append(msg, &iter);
+
+	dbus_bool_t ok = true;
+
+	/* Set name and mode */
+	ok = ok && bus_message_append(&iter, "ss", namebuf, "fail");
+
+	/* Set properties */
+	ok = ok && dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "(sv)", &props);
+
+	ok = ok && bus_message_append(&props, "(sv)(sv)(sv)(sv)",
+			"Description", "s", "/usr/bin/true",
+			"Delegate", "b", 1, /* Delegate all cgroup controllers to us */
+			"Slice", "s", parent,
+			"PIDs", "au", 1, (uint32_t)getpid());
+
+	ok = ok && dbus_message_iter_close_container(&iter, &props);
+
+	/* Systemd expects auxiliary units in the message, and we have none */
+	ok = ok && bus_message_append(&iter, "a(sa(sv))", 0);
+
+	if (!ok) {
+		errno = -ENOMEM;
+		err(1, "cgroup_systemd_join_cgroup: preparing D-Bus message");
+	}
+
+	/* Perform the call. Systemd will place our process into the cgroup for us. */
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(bus, msg, -1, &dberr);
+	if (!reply) {
+		errx(1, "cgroup_systemd_join_cgroup: failed to start transient scope unit: %s", dberr.message);
+	}
+
+	dbus_message_unref(msg);
+	dbus_message_unref(reply);
+
+	/* Wait for the scope creation job to complete */
+	for (;;) {
+		dbus_connection_read_write(bus, -1);
+		msg = dbus_connection_pop_message(bus);
+
+		if (msg == NULL) {
+			continue;
+		}
+
+		if (!dbus_message_is_signal(msg, INTERFACE, "JobRemoved")) {
+			goto next;
+		}
+		if (!dbus_message_iter_init(msg, &iter)) {
+			errx(1, "cgroup_systemd_join_cgroup: JobRemoved signal message has no arguments");
+		}
+
+		// ID
+		if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_UINT32) {
+			goto bad_sig;
+		}
+		if (!dbus_message_iter_next(&iter)) {
+			goto bad_sig;
+		}
+
+		// Path
+		if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_OBJECT_PATH) {
+			goto bad_sig;
+		}
+		if (!dbus_message_iter_next(&iter)) {
+			goto bad_sig;
+		}
+
+		// Unit
+		if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING) {
+			goto bad_sig;
+		}
+		if (!dbus_message_iter_next(&iter)) {
+			goto bad_sig;
+		}
+
+		// Result
+		if (dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING) {
+			goto bad_sig;
+		}
+		char *result;
+		dbus_message_iter_get_basic(&iter, &result);
+		if (strcmp(result, "done")) {
+			errx(1, "cgroup_systemd_join_cgroup: failed to start transient scope unit: job finished with result '%s'", result);
+		}
+
+	next:
+		dbus_message_unref(msg);
+		break;
+
+	bad_sig:
+		errx(1, "cgroup_systemd_join_cgroup: JobRemoved signal message does not have signature 'uoss'");
+	}
+
+	char selfcgroup[PATH_MAX];
+	if (!cgroup_read_current(selfcgroup)) {
+		errx(1, "could not determine current cgroup; are you using cgroups v2?");
+	}
+	int cgroupfd = open(selfcgroup, O_RDONLY | O_DIRECTORY, 0);
+	if (cgroupfd == -1) {
+		err(1, "cgroup_systemd_join_cgroup: open %s", selfcgroup);
+	}
+
+	return cgroupfd;
+}
+
+const struct cgroup_driver_funcs cgroup_driver_systemd = {
+	.init         = cgroup_systemd_driver_init,
+	.join_cgroup  = cgroup_systemd_join_cgroup,
+	.current_path = cgroup_systemd_current_path,
+};

--- a/config.h.in
+++ b/config.h.in
@@ -14,5 +14,6 @@
 
 #mesondefine HAVE_SYS_mount_setattr
 #mesondefine HAVE_close_range
+#mesondefine HAVE_SYSTEMD
 
 #endif /* !CONFIG_H_ */

--- a/enter.h
+++ b/enter.h
@@ -13,7 +13,9 @@
 # include <sys/stat.h>
 # include <time.h>
 # include <unistd.h>
+
 # include "bst_limits.h"
+# include "cgroup.h"
 # include "mount.h"
 # include "net.h"
 # include "ns.h"
@@ -88,6 +90,7 @@ struct entry_settings {
 
 	mode_t umask;
 
+	enum cgroup_driver cgroup_driver;
 	char *cgroup_path;
 
 	struct climit climits[MAX_CGROUPS];

--- a/generate
+++ b/generate
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+(echo "/* Copyright © 2020 Arista Networks, Inc. All rights reserved."; \
+ echo " *"; \
+ echo " * Use of this source code is governed by the MIT license that can be found" ;\
+ echo " * in the LICENSE file."; \
+ echo " */"; \
+ echo ""; \
+ echo "/* This file is generated from usage.txt. Do not edit. */"; \
+ xxd -i usage.txt) > usage.c

--- a/main.c
+++ b/main.c
@@ -58,6 +58,10 @@ enum {
 	OPTION_PIDFILE,
 	OPTION_IP,
 	OPTION_ROUTE,
+	OPTION_TTY,
+	OPTION_CLOSE_FD,
+	OPTION_CGROUP_DRIVER,
+
 	OPTION_NO_FAKE_DEVTMPFS,
 	OPTION_NO_DERANDOMIZE,
 	OPTION_NO_PROC_REMOUNT,
@@ -66,8 +70,6 @@ enum {
 	OPTION_NO_INIT,
 	OPTION_NO_ENV,
 	OPTION_NO_COPY_HARD_RLIMITS,
-	OPTION_TTY,
-	OPTION_CLOSE_FD,
 };
 
 static void process_nslist_entry(const char **out, const char *share, const char *path, int append_nsname)
@@ -273,6 +275,7 @@ int main(int argc, char *argv[], char *envp[])
 	opts.uid   = (uid_t) -1;
 	opts.gid   = (gid_t) -1;
 	opts.umask = (mode_t) -1;
+	opts.cgroup_driver = (enum cgroup_driver) -1;
 
 	static struct option options[] = {
 		{ "help",       no_argument,        NULL,           'h' },
@@ -309,6 +312,7 @@ int main(int argc, char *argv[], char *envp[])
 		{ "route",              required_argument, NULL, OPTION_ROUTE           },
 		{ "tty",                optional_argument, NULL, OPTION_TTY             },
 		{ "close-fd",           optional_argument, NULL, OPTION_CLOSE_FD        },
+		{ "cgroup-driver",      required_argument, NULL, OPTION_CGROUP_DRIVER   },
 
 		/* Opt-out feature flags */
 		{ "no-copy-hard-rlimits", no_argument, NULL, OPTION_NO_COPY_HARD_RLIMITS },
@@ -656,6 +660,14 @@ int main(int argc, char *argv[], char *envp[])
 
 			case OPTION_CGROUP:
 				opts.cgroup_path = optarg;
+				break;
+
+			case OPTION_CGROUP_DRIVER:
+				if (strcmp(optarg, "native") == 0) {
+					opts.cgroup_driver = CGROUP_DRIVER_NATIVE;
+				} else {
+					errx(2, "unsupported cgroup driver '%s'", optarg);
+				}
 				break;
 
 			case OPTION_NO_FAKE_DEVTMPFS:

--- a/main.c
+++ b/main.c
@@ -665,6 +665,10 @@ int main(int argc, char *argv[], char *envp[])
 			case OPTION_CGROUP_DRIVER:
 				if (strcmp(optarg, "native") == 0) {
 					opts.cgroup_driver = CGROUP_DRIVER_NATIVE;
+#ifdef HAVE_SYSTEMD
+				} else if (strcmp(optarg, "systemd") == 0) {
+					opts.cgroup_driver = CGROUP_DRIVER_SYSTEMD;
+#endif
 				} else {
 					errx(2, "unsupported cgroup driver '%s'", optarg);
 				}

--- a/man/bst.1.scd
+++ b/man/bst.1.scd
@@ -229,38 +229,55 @@ _VAR=value_ before the executable to run.
 
 	Supported options are described in more detail in the *NETWORKING* section.
 
-\--cgroup <path>
-	Optionally specify the cgroup directory that bst will operate within. bst will create a
-	cgroup sub-hierarchy at the <path>. If not provided, <path> will assume the
-	cgroup directory of the current process.
+\--cgroup-driver <driver>
+	Specify the cgroup driver to use.
+
+	Valid values are _native_, or _systemd_.
+
+	The _native_ driver manages and cleans up cgroups directly, with no
+	intermediary. It is appropriate to use in situations where nothing is
+	owning the cgroups tree, like in most containers.
+
+	The _systemd_ driver defers the management of the cgroup to systemd. It
+	does so by creating a systemd scope unit via the D-Bus API. This driver
+	is appropriate for systemd-managed systems, as directly creating cgroups
+	without informing systemd on these systems causes bst to step on systemd's
+	toes, and vice-versa.
+
+	By default, *bst* will attempt to use the _systemd_ driver before falling
+	back to the _native_ driver.
+
+\--cgroup <name>
+	Specify the cgroup that *bst* will operate within. The interpretation of the
+	value depends on the driver in use:
+
+	If the driver is _native_, then this is a path to the cgroup directory that
+	will be used to create the *bst* cgroup.
+
+	If the driver is _systemd_, then this is the name of a systemd slice unit
+	under which the *bst* cgroup will be placed.
 
 \--limit <resource>=<value>
 	Apply a cgroup quota <value> to the provided <resource>. Multiple limits can
 	be specified in conjunction.
 
-	<value>=<resource> follow the interface of the underlying cgroup.
+	<resource>=<value> follow the interface of the underlying cgroup.
 
-	Valid <resource>=<value> pairs are:
-	- cpu.max=$MAX
-	- cpu.max="$MAX $PERIOD"
-	- cpu.weight=$WEIGHT
-	- memory.min=$MIN
-	- memory.low=$LOW
-	- memory.high=$HIGH
-	- memory.max=$MAX
-	- memory.swap.high=$HIGH
-	- memory.swap.max=$MAX
-	- io.weight=$WEIGHT
-	- io.max="$MAJ:$MIN rbps=$RIOPS wbps=$WBPS riops=$RIOPS wiops=$WIOPS"
-	- io.latency="$MAJ:$MIN target$MS"
-	- pids.max=$MAX
+	Common <resource>=<value> pairs include, for instance:
+	- *cpu.max*=$MAX
+	- *cpu.weight*=$WEIGHT
+	- *memory.min*=$MIN
+	- *memory.max*=$MAX
 
-	To use a <resource> ensure that the proper controller (io, cpu, memory) is
-	added to the cgroup.controller at the current process's cgroup or at the <path>
-	specified by --cgroup if provided.
+	Consult the CGroupsV2 documentation of your kernel for a full list of
+	possible resources.
+
+	To use a <resource> ensure that the proper controller (io, cpu, memory) has
+	been enabled in the parent cgroup.
 
 \--try-limit <resource>=<value>
-	Identical to _--limit_, but ignored if the resouce is unsupported by the kernel.
+	Identical to _--limit_, but ignored if the resouce is unsupported by the
+	kernel, or hasn't been enabled in the cgroup.subtree_control file.
 
 \--rlimit <resource>=<value>++
 \--rlimit <resource>=[hard]:[soft]

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,8 @@ bst_sources = [
 	'bst_limits.c',
 	'capable.c',
 	'compat.c',
+	'cgroup.c',
+	'cgroup_native.c',
 	'enter.c',
 	'err.c',
 	'fd.c',

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,9 @@ config.set('version', version)
 config.set('HAVE_SYS_mount_setattr', cc.has_header_symbol('syscall.h', 'SYS_mount_setattr'))
 config.set('HAVE_close_range', cc.has_function('close_range'))
 
+libdbus = dependency('dbus-1', required: false)
+config.set('HAVE_SYSTEMD', libdbus.found())
+
 configure_file(input: 'config.h.in', output: 'config.h', configuration: config)
 
 bst_init_sources = [
@@ -106,7 +109,11 @@ bst_sources = [
 	'userns.c',
 ]
 
-executable('bst', bst_sources, install: true)
+if libdbus.found()
+	bst_sources += ['cgroup_systemd.c']
+endif
+
+executable('bst', bst_sources, install: true, dependencies: [libdbus])
 
 if not get_option('no-setcap-or-suid')
 	capabilities = {

--- a/outer.h
+++ b/outer.h
@@ -21,8 +21,7 @@ struct outer_helper {
 	struct nic_options *nics;
 	size_t nnics;
 
-	bool cgroup_enabled;
-
+	enum cgroup_driver cgroup_driver;
 	char *cgroup_path;
 	struct climit *climits;
 	size_t nclimits;

--- a/usage.txt
+++ b/usage.txt
@@ -43,8 +43,9 @@ Options:
       --ip <address>,<dev>          Add an IP address to the specified interface.
       --route <route>               Add a route in the network namespace.
 
-      --cgroup <path>               Optionally set path for bst cgroup to be
-                                    created if --limits specified.
+      --cgroup-driver <driver>      Specify cgroup driver to use (native, systemd).
+      --cgroup <name>               Specify cgroup to join -- value dependent
+                                    on the cgroup driver in use.
       --limit <res>=<value>         Set the specified cgroup resource to the
                                     provided value(s).
       --try-limit <res>=<value>     Same as --limit but fails silently when the


### PR DESCRIPTION
The current cgroup implementation was in a very sad state, and was overall hard to use correctly, because it was trying to conciliate two very different system configurations: systemd-managed systems, and the contrary.

This PR makes bst limits more turnkey; that is, it now "just works" on the vast majority of systems without any additional configuration.

---

More specifically, this PR does two things: first, it refactors the current cgroup code into cgroup "drivers", and it provides two driver implementations: native, and systemd.

The native driver manages and cleans up cgroups directly, with no intermediary. It is appropriate to use in situations where nothing is owning the cgroups tree, like in most containers.

The systemd driver defers the management of the cgroup to systemd. It does so by creating a systemd scope unit via the D-Bus API. This driver is appropriate for systemd-managed systems, as directly creating cgroups without informing systemd on these systems causes bst to step on systemd's toes, and vice-versa.

bst will attempt to use the systemd driver before falling back to the native driver.