### PR TITLE
cgroup: fix various issues with compatibility with older bst spacetimes

### DIFF
--- a/cgroup.h
+++ b/cgroup.h
@@ -4,14 +4,15 @@
 # include <stdbool.h>
 
 struct cgroup_driver_funcs {
-    int (*init)(bool fatal);
-    int (*join_cgroup)(const char *parent, const char *name);
-    bool (*current_path)(char *out);
+	int (*init)(bool fatal);
+	int (*join_cgroup)(const char *parent, const char *name);
+	bool (*current_path)(char *out);
 };
 
 enum cgroup_driver {
-    CGROUP_DRIVER_NATIVE,
-    CGROUP_DRIVER_SYSTEMD,
+	CGROUP_DRIVER_NONE,
+	CGROUP_DRIVER_NATIVE,
+	CGROUP_DRIVER_SYSTEMD,
 };
 
 int cgroup_driver_init(enum cgroup_driver driver, bool fatal);

--- a/cgroup_systemd.c
+++ b/cgroup_systemd.c
@@ -224,8 +224,9 @@ static int cgroup_systemd_join_cgroup(const char *parent, const char *name)
 	ok = ok && dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "(sv)", &props);
 
 	ok = ok && bus_message_append(&props, "(sv)(sv)(sv)(sv)",
-			"Description", "s", "/usr/bin/true",
+			"Description", "s", "bst",
 			"Delegate", "b", 1, /* Delegate all cgroup controllers to us */
+			"CollectMode", "s", "inactive-or-failed", /* Make sure failed invocations are garbage-collected */
 			"Slice", "s", parent,
 			"PIDs", "au", 1, (uint32_t)getpid());
 

--- a/main.c
+++ b/main.c
@@ -663,7 +663,9 @@ int main(int argc, char *argv[], char *envp[])
 				break;
 
 			case OPTION_CGROUP_DRIVER:
-				if (strcmp(optarg, "native") == 0) {
+				if (strcmp(optarg, "none") == 0) {
+					opts.cgroup_driver = CGROUP_DRIVER_NONE;
+				} else if (strcmp(optarg, "native") == 0) {
 					opts.cgroup_driver = CGROUP_DRIVER_NATIVE;
 #ifdef HAVE_SYSTEMD
 				} else if (strcmp(optarg, "systemd") == 0) {

--- a/man/bst.1.scd
+++ b/man/bst.1.scd
@@ -235,7 +235,7 @@ spacetime process.
 \--cgroup-driver <driver>
 	Specify the cgroup driver to use.
 
-	Valid values are _native_, or _systemd_.
+	Valid values are _native_, _systemd_, or _none_.
 
 	The _native_ driver manages and cleans up cgroups directly, with no
 	intermediary. It is appropriate to use in situations where nothing is
@@ -246,6 +246,10 @@ spacetime process.
 	is appropriate for systemd-managed systems, as directly creating cgroups
 	without informing systemd on these systems causes bst to step on systemd's
 	toes, and vice-versa.
+
+	The _none_ driver disables cgroup support -- *bst* will leave the child
+	process in the parent control group. Using this driver is not recommended
+	for typical use, but has worth in testing or maintaining compatibility.
 
 	By default, *bst* will attempt to use the _systemd_ driver before falling
 	back to the _native_ driver.


### PR DESCRIPTION
It is currently not possible to use bst with older versions of bst due to the older spacetime leaving the cgroup unconfigured. This means that /sys/fs/cgroup is unusable to the inner/newer bst, which in turn promptly fails.