### PR TITLE
mount,dev: add support for /dev/kvm

### DIFF
--- a/mount.c
+++ b/mount.c
@@ -258,6 +258,7 @@ void mount_entries(const char *root, const struct mount_entry *mounts, size_t nm
 				{ "random",  S_IFCHR | 0666, makedev(1, 8) },
 				{ "urandom", S_IFCHR | 0666, makedev(1, 9) },
 				{ "net/tun", S_IFCHR | 0666, makedev(10, 200) },
+				{ "kvm",     S_IFCHR | 0666, makedev(10, 232) },
 			};
 
 			for (size_t i = 0; i < lengthof(devices); ++i) {


### PR DESCRIPTION
This device is safe for unprivileged access, and is almost a must-have for running virtual machines with any reasonable performance.