### PR TITLE
fd: mark fds with CLOEXEC instead of closing them

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -11,6 +11,7 @@
 
 /* From the kernel headers */
 # define BST_CLOSE_RANGE_UNSHARE (1U << 1)
+# define BST_CLOSE_RANGE_CLOEXEC (1U << 2)
 
 size_t strlcpy(char *restrict dst, const char *restrict src, size_t size);
 unsigned int parse_fd(char *optarg);

--- a/enter.c
+++ b/enter.c
@@ -508,6 +508,12 @@ int enter(struct entry_settings *opts)
 		}
 	}
 
+	for (const struct close_range *range = opts->close_fds; range < opts->close_fds + opts->nclose_fds; ++range) {
+		if (bst_close_range(range->from, range->to, BST_CLOSE_RANGE_CLOEXEC) == -1) {
+			err(1, "close_range %d %d", range->from, range->to);
+		}
+	}
+
 	/*
 	 * Only mount a a cgroup hierarchy over sys/fs/cgroup if:
 	 *  1) The user has not specified --no_cgroup_remount
@@ -800,11 +806,6 @@ int enter(struct entry_settings *opts)
 			}
 			const char *init = opts->init + rootlen;
 
-			for (const struct close_range *range = opts->close_fds; range < opts->close_fds + opts->nclose_fds; ++range) {
-				if (bst_close_range(range->from, range->to, BST_CLOSE_RANGE_UNSHARE) == -1) {
-					err(1, "close_range %d %d", range->from, range->to);
-				}
-			}
 			execve(init, argv, opts->envp);
 			err(1, "execve %s", init);
 		}


### PR DESCRIPTION
--close-fd would fail to work on some systems when entering spacetimes where /proc would not be mounted, because it would attempt to iterate over all file descriptors as listed in /proc/self/fd right before execve, and of course this cannot work when /proc isn't there.

This fixes the problem by doing the operation earlier, after the setup script has ran, but before pivoting roots; of course, we can't close the range outright, since we're likely to use some of these file descriptors, but we can instead set the CLOEXEC bit on them.