### PR TITLE
cgroup,setup: set CGROUP_PATH in setup program with full path to current cgroup

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -448,6 +448,12 @@ int enter(struct entry_settings *opts)
 
 	outer_helper_sync(&outer_helper);
 
+	/* Read the current cgroup before ns_enter_postfork; this allows us
+	   to get the real path to the cgroup */
+	char cgroup_path[PATH_MAX];
+	if (!cgroup_read_current(cgroup_path)) {
+		errx(1, "could not determine current cgroup; are you using cgroups v2?");
+	}
 	ns_enter_postfork(namespaces, ns_len);
 
 	outer_helper_close(&outer_helper);
@@ -480,6 +486,7 @@ int enter(struct entry_settings *opts)
 			/* Set some extra useful environment */
 			setenv("ROOT", root, 1);
 			setenv("EXECUTABLE", opts->pathname, 1);
+			setenv("CGROUP_PATH", cgroup_path, 1);
 
 			extern char **environ;
 

--- a/man/bst.1.scd
+++ b/man/bst.1.scd
@@ -529,6 +529,9 @@ The following environment variables are accessible to the setup program:
 *EXECUTABLE*
 	Set to the executable name that will be executed after the setup is done.
 
+*CGROUP_PATH*
+	Set to the path of the cgroup of the process that will be executed.
+
 # NETWORKING
 
 ## Creating network interfaces


### PR DESCRIPTION
It is useful for the setup program to be able to change or inspect the cgroup directory of the spacetime process. The problem is that by the time the setup program executes, bst will have pivoted into the cgroup namespace, leaving it with no consistent way to know what the path of that cgroup is.

This commit arranges for the path of the cgroup to be defined in the CGROUP_PATH environment variable when the setup program executes.