### PR TITLE
cgroup,setup: make CGROUP_PATH optional

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -452,7 +452,7 @@ int enter(struct entry_settings *opts)
 	   to get the real path to the cgroup */
 	char cgroup_path[PATH_MAX];
 	if (!cgroup_read_current(cgroup_path)) {
-		errx(1, "could not determine current cgroup; are you using cgroups v2?");
+		cgroup_path[0] = '\0';
 	}
 	ns_enter_postfork(namespaces, ns_len);
 
@@ -486,7 +486,9 @@ int enter(struct entry_settings *opts)
 			/* Set some extra useful environment */
 			setenv("ROOT", root, 1);
 			setenv("EXECUTABLE", opts->pathname, 1);
-			setenv("CGROUP_PATH", cgroup_path, 1);
+			if (cgroup_path[0] != '\0') {
+				setenv("CGROUP_PATH", cgroup_path, 1);
+			}
 
 			extern char **environ;
 

--- a/man/bst.1.scd
+++ b/man/bst.1.scd
@@ -530,7 +530,9 @@ The following environment variables are accessible to the setup program:
 	Set to the executable name that will be executed after the setup is done.
 
 *CGROUP_PATH*
-	Set to the path of the cgroup of the process that will be executed.
+	Set to the path of the cgroup of the process that will be executed. Can
+	be missing if bst could not determine the cgroup path (e.g. only cgroups v1
+	are available, or /proc isn't mounted)
 
 # NETWORKING
 


### PR DESCRIPTION
Some users of bst are still stuck on cgroups v1, and 588d370 ("cgroup,setup: set CGROUP_PATH in setup program with full path to current cgroup") broke the basic, non-cgroup use of bst.

This commit makes the failure to determine the current cgroup path non-fatal; the setup program has the responsibility to fail if it needs it.