### PR TITLE
cgroup,cleaner: report errors in syslog

### DIFF
--- a/errutil.h
+++ b/errutil.h
@@ -7,7 +7,12 @@
 #ifndef ERRUTIL_H_
 # define ERRUTIL_H_
 
+enum {
+	ERR_USE_SYSLOG = 1,
+};
+
 extern void (*err_exit)(int);
 extern const char *err_line_ending;
+extern int err_flags;
 
 #endif /* !ERRUTIL_H */


### PR DESCRIPTION
The native cgroup cleaner used to report errors on stderr, but at that point the parent bst process might have already died, feeding the error message asynchronously on the pty, or worse, the pipe stderr is connected to might have already been closed.

To avoid losing precious debugging data, log any errors in the cgroup cleaner process to syslog instead.