### PR TITLE
cli: Create BST_VERBOSITY to enable/disable warnings

### DIFF
--- a/err.c
+++ b/err.c
@@ -40,7 +40,7 @@ static int parsedverbosity(void)
 	char *endPtr;
 	int iVerbosity = strtol(pszVerbosity, &endPtr, 10);
 	if (*endPtr != '\0') {
-		err(2, "un-parsable value of BST_VERBOSITY");
+		err(2, "un-parsable value of BST_VERBOSITY\n");
 	}
 	return iVerbosity;
 }
@@ -90,11 +90,8 @@ static void vwarnsyslog(int errcode, const char *fmt, va_list vl)
 	vsyslog(LOG_ERR, fmt, vl);
 }
 
-void vwarn(const char *fmt, va_list vl)
+static void vwarn(const char *fmt, va_list vl)
 {
-    if (!(err_flags & ERR_VERBOSE)) {
-        return;
-    }
 	if (err_flags & ERR_USE_SYSLOG) {
 		vwarnsyslog(errno, fmt, vl);
 		return;
@@ -104,11 +101,8 @@ void vwarn(const char *fmt, va_list vl)
 	fdprintf(STDERR_FILENO, ": %s%s", strerror(errno), err_line_ending);
 }
 
-void vwarnx(const char *fmt, va_list vl)
+static void vwarnx(const char *fmt, va_list vl)
 {
-    if (!(err_flags & ERR_VERBOSE)) {
-        return;
-    }
 	if (err_flags & ERR_USE_SYSLOG) {
 		vwarnsyslog(0, fmt, vl);
 		return;
@@ -120,6 +114,9 @@ void vwarnx(const char *fmt, va_list vl)
 
 void warn(const char *fmt, ...)
 {
+	if (!(err_flags & ERR_VERBOSE)) {
+		return;
+	}
 	va_list vl;
 	va_start(vl, fmt);
 	vwarn(fmt, vl);
@@ -128,6 +125,9 @@ void warn(const char *fmt, ...)
 
 void warnx(const char *fmt, ...)
 {
+	if (!(err_flags & ERR_VERBOSE)) {
+		return;
+	}
 	va_list vl;
 	va_start(vl, fmt);
 	vwarnx(fmt, vl);

--- a/err.c
+++ b/err.c
@@ -31,7 +31,6 @@ int err_flags = 0;
    being the most verbose and 0 being the least verbose. The default
    verbosity level is 1. */
 
-noreturn void err(int eval, const char *fmt, ...);
 static int parsedverbosity(void)
 {
 	char *pszVerbosity = getenv("BST_VERBOSITY");
@@ -41,7 +40,7 @@ static int parsedverbosity(void)
 	char *endPtr;
 	int iVerbosity = strtol(pszVerbosity, &endPtr, 10);
 	if (*endPtr != '\0') {
-        err(2, "un-parsable value of BST_VERBOSITY");
+		err(2, "un-parsable value of BST_VERBOSITY");
 	}
 	return iVerbosity;
 }

--- a/err.c
+++ b/err.c
@@ -31,29 +31,28 @@ int err_flags = 0;
    being the most verbose and 0 being the least verbose. The default
    verbosity level is 1. */
 
-static int parsedverbosity()
+noreturn void err(int eval, const char *fmt, ...);
+static int parsedverbosity(void)
 {
-    char *pszVerbosity = getenv("BST_VERBOSITY");
-    if (pszVerbosity == NULL) {
-        return 1;
-    }
-    char *endPtr;
-    int iVerbosity = strtol(pszVerbosity, &endPtr, 10);
-    if (*endPtr != '\0') {
-        // Soemthing went wrong during parsing. This isn't
-        // critical so let's just ignore the parameter.
-        return 1;
-    }
-    return iVerbosity;
+	char *pszVerbosity = getenv("BST_VERBOSITY");
+	if (pszVerbosity == NULL) {
+		return 1;
+	}
+	char *endPtr;
+	int iVerbosity = strtol(pszVerbosity, &endPtr, 10);
+	if (*endPtr != '\0') {
+        err(2, "un-parsable value of BST_VERBOSITY");
+	}
+	return iVerbosity;
 }
 
-void init_logverbosity()
+void init_logverbosity(void)
 {
-    int iVerbosity = parsedverbosity();
+	int iVerbosity = parsedverbosity();
 
-    if (iVerbosity >= 1) {
-        err_flags |= ERR_VERBOSE;
-    }
+	if (iVerbosity >= 1) {
+		err_flags |= ERR_VERBOSE;
+	}
 }
 
 /* fdprintf and vfdprintf are fork-safe versions of fprintf and vfprintf. */

--- a/errutil.h
+++ b/errutil.h
@@ -9,10 +9,13 @@
 
 enum {
 	ERR_USE_SYSLOG = 1,
+
+    ERR_VERBOSE = 2,
 };
 
 extern void (*err_exit)(int);
 extern const char *err_line_ending;
+void init_logverbosity();
 extern int err_flags;
 
 #endif /* !ERRUTIL_H */

--- a/errutil.h
+++ b/errutil.h
@@ -10,7 +10,7 @@
 enum {
 	ERR_USE_SYSLOG = 1,
 
-    ERR_VERBOSE = 2,
+	ERR_VERBOSE = 2,
 };
 
 extern void (*err_exit)(int);

--- a/errutil.h
+++ b/errutil.h
@@ -7,6 +7,8 @@
 #ifndef ERRUTIL_H_
 # define ERRUTIL_H_
 
+#include <stdnoreturn.h>
+
 enum {
 	ERR_USE_SYSLOG = 1,
 
@@ -16,6 +18,7 @@ enum {
 extern void (*err_exit)(int);
 extern const char *err_line_ending;
 void init_logverbosity();
+noreturn void err(int eval, const char *fmt, ...);
 extern int err_flags;
 
 #endif /* !ERRUTIL_H */

--- a/main.c
+++ b/main.c
@@ -263,6 +263,7 @@ int usage(int error, char *argv0)
 
 int main(int argc, char *argv[], char *envp[])
 {
+    init_logverbosity();
 	init_capabilities();
 
 	static struct entry_settings opts;

--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@
 #include "capable.h"
 #include "compat.h"
 #include "enter.h"
+#include "errutil.h"
 #include "kvlist.h"
 #include "util.h"
 #include "path.h"


### PR DESCRIPTION
Warnings are usually helpful to end-users but when bst is invoked by automations in a well controlled environment it is often preferable to only print fatal errors.

With this change, setting BST_VERBOSITY=0 will turn off non-fatal warnings.