### PR TITLE
cgroup,cleaner: wait on level-triggered transitions

### DIFF
--- a/cgroup.c
+++ b/cgroup.c
@@ -191,7 +191,7 @@ static void run_cleaner_child(int lock, int parentfd, const char *name)
 	char populated[BUFSIZ];
 	for (;;) {
 		int ready = epoll_wait(epollfd, &event, 1, -1);
-		if (ready == -1) {
+		if (ready == -1 && errno != EINTR) {
 			warn("run_cgroup_child: epoll_wait cgroup.events");
 			goto recursiveClean;
 		}

--- a/cgroup.c
+++ b/cgroup.c
@@ -164,7 +164,7 @@ static void run_cleaner_child(int lock, int parentfd, const char *name)
 	}
 
 	struct epoll_event event = {
-		.events = EPOLLET,
+		.events = 0,
 	};
 
 	int epollfd = epoll_create1(0);


### PR DESCRIPTION
The old code used edge-triggered transitions for epoll_wait on the
cgroup.events file, which meant we were losing some events if we weren't
fast enough to process them. This, in turn, caused the unlucky cleaner
processes to hang on an epoll_wait, unable to clean up the unpopulated
cgroup.

With this commit, we now operate on level-triggered transitions, which
allows cleaners to do their jobs properly.