### PR TITLE
tty: stop spamming VEOF on raw terminals, and cleanly handle EOF

### DIFF
--- a/fd.h
+++ b/fd.h
@@ -10,5 +10,6 @@
 int recv_fd(int socket);
 void send_fd(int socket, int fd);
 void rebind_fds_and_close_rest(int start_fd, ...);
+void close_null(int fd);
 
 #endif /* !FD_H */


### PR DESCRIPTION
This PR contains two changes:

The first one is a change in how we handle hangups from stdin; if the child pty is not in raw mode (or rather, is in non-canonical mode), and therefore isn't interpreting VEOF, then we won't send any. Instead, we now just hang up the terminal, which causes the session to die with a SIGHUP.

The second fixes a weirdity I noticed where we would not handle EOF properly, and commands like `bst --tty cat </dev/null` would not terminate.