### PR TITLE
cgroup: use proc fd when reading details about current process for explicitness

### DIFF
--- a/cgroup.h
+++ b/cgroup.h
@@ -18,7 +18,7 @@ enum cgroup_driver {
 int cgroup_driver_init(enum cgroup_driver driver, bool fatal);
 bool cgroup_current_path(char *path);
 int cgroup_join(const char *parent, const char *name);
-bool cgroup_read_current(char *path);
+bool cgroup_read_current(int procfd, char *path);
 void cgroup_enable_controllers(int cgroupfd);
 void cgroup_start_cleaner(int parentfd, const char *name);
 

--- a/cgroup_native.c
+++ b/cgroup_native.c
@@ -12,7 +12,7 @@ static int cgroup_native_driver_init(bool fatal)
 {
 	/* The native driver can only work with cgroup v2. Perform some sanity
 	   checks to verify this. */
-	if (!cgroup_read_current(NULL)) {
+	if (!cgroup_read_current(-1, NULL)) {
 		return -1;
 	}
 
@@ -35,7 +35,7 @@ static int cgroup_native_driver_init(bool fatal)
 
 static bool cgroup_native_current_path(char *path)
 {
-	return cgroup_read_current(path);
+	return cgroup_read_current(-1, path);
 }
 
 static int cgroup_native_join_cgroup(const char *parent, const char *name)

--- a/cgroup_systemd.c
+++ b/cgroup_systemd.c
@@ -308,7 +308,7 @@ static int cgroup_systemd_join_cgroup(const char *parent, const char *name)
 	}
 
 	char selfcgroup[PATH_MAX];
-	if (!cgroup_read_current(selfcgroup)) {
+	if (!cgroup_read_current(-1, selfcgroup)) {
 		errx(1, "could not determine current cgroup; are you using cgroups v2?");
 	}
 	int cgroupfd = open(selfcgroup, O_RDONLY | O_DIRECTORY, 0);


### PR DESCRIPTION
Knowing in which context you're running is hard, when most of the namespaces can be interchanged at any time during init.

Instead of tossing a coin, use file descriptors to /proc that we open early.