### PR TITLE
Refactor order of unshare operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bst
 bst-unpersist
 bst-init
 tags
+version/
+bst_limits./


### PR DESCRIPTION
Before this PR we would attempt to sort the namespaces to enter in order to decide what order to enter those namespaces. The sorting logic was somewhat complex and difficult to reason about.

With this change, we now just loop through the list of namespaces 3 times. During each loop, we unshare only a subset of namepaces (nonoverlapping subsets). This guaruntees that our unshares happen in roughly the order that they were declared in the namespaces list.