### PR TITLE
enter: pass nsactions array rather than path array

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -142,7 +142,7 @@ int enter(struct entry_settings *opts)
 	}
 
 	int timens_offsets = -1;
-	if (opts->shares[NS_TIME] != SHARE_WITH_PARENT) {
+	if (opts->nsactions[NS_TIME] != NSACTION_SHARE_WITH_PARENT) {
 
 		/* Because this process is privileged, /proc/self/timens_offsets
 		   is unfortunately owned by root and not ourselves, so we have
@@ -158,14 +158,13 @@ int enter(struct entry_settings *opts)
 			/* The kernel evidently doesn't support time namespaces yet.
 			   Don't try to open the time namespace file with --share-all=<dir>,
 			   or try to unshare or setns the time namespace below. */
-			opts->shares[NS_TIME] = SHARE_WITH_PARENT;
+			opts->nsactions[NS_TIME] = NSACTION_SHARE_WITH_PARENT;
 		}
 
 		reset_capabilities();
 	}
 
-	enum nsaction nsactions[MAX_NS];
-	opts_to_nsactions(opts->shares, nsactions);
+	enum nsaction *nsactions = opts->nsactions;
 
 	if (nsactions[NS_NET] != NSACTION_UNSHARE && opts->nnics > 0) {
 		errx(1, "cannot create NICs when not in a network namespace");

--- a/enter.h
+++ b/enter.h
@@ -48,15 +48,9 @@ enum {
 	MAX_CLOSE_FDS = 4096,
 };
 
-/* SHARE_WITH_PARENT is a special value for entry_settings.shares[ns]. */
-# define SHARE_WITH_PARENT ((char *) -1)
-
 struct entry_settings {
-	/* shares[] is indexed by SHARE_CGROUP, etc.  Legal values are:
-	   NULL: unshare.
-	   SHARE_WITH_PARENT: special marker meaning don't unshare or setns.
-	   filename: setns to the given namespace file. */
-	const char *shares[MAX_NS];
+	/* nsactions[] is indexed by NS_CGROUP, etc.  */
+	enum nsaction nsactions[MAX_NS];
 	const char *persist[MAX_NS];
 
 	const char *pathname;

--- a/ns.c
+++ b/ns.c
@@ -40,7 +40,7 @@ int ns_cloneflag(enum nstype ns)
 	return flags[ns].flag;
 }
 
-static bool is_nsfd_current(int nsfd, const char *name)
+bool is_nsfd_current(int nsfd, const char *name)
 {
 	const char *path = makepath("/proc/self/ns/%s", name);
 
@@ -59,33 +59,6 @@ static bool is_nsfd_current(int nsfd, const char *name)
 	}
 
 	return self.st_ino == stat.st_ino;
-}
-
-void opts_to_nsactions(const char *shares[], enum nsaction *nsactions)
-{
-	for (enum nstype ns = 0; ns < MAX_NS; ns++) {
-		const char *share = shares[ns];
-		if (share == NULL) {
-			nsactions[ns] = NSACTION_UNSHARE;
-		} else if (share == SHARE_WITH_PARENT) {
-			nsactions[ns] = NSACTION_SHARE_WITH_PARENT;
-		} else {
-			nsactions[ns] = open(share, O_RDONLY | O_CLOEXEC);
-			if (nsactions[ns] < 0) {
-				err(1, "open %s", share);
-			}
-
-			/* If the nsfd refers to the same namespace as the one we are
-			   currently in, treat as for SHARE_WITH_PARENT.
-
-			   We want to give semantics to --share <ns>=/proc/self/ns/<ns>
-			   being the same as --share <ns>. */
-			if (is_nsfd_current(nsactions[ns], ns_name(ns))) {
-				close(nsactions[ns]);
-				nsactions[ns] = NSACTION_SHARE_WITH_PARENT;
-			}
-		}
-	}
 }
 
 static void ns_enter_one(struct nsid *ns)

--- a/ns.h
+++ b/ns.h
@@ -61,7 +61,7 @@ struct nsid {
 const char *ns_name(enum nstype);
 int ns_cloneflag(enum nstype);
 
-void opts_to_nsactions(const char *shares[], enum nsaction *nsactions);
+bool is_nsfd_current(int nsfd, const char *name);
 void ns_enter_prefork(struct nsid *namespaces, size_t *len);
 void ns_enter_postfork(struct nsid *namespaces, size_t len);
 


### PR DESCRIPTION
Before this commit, we used to construct shared namespace paths purely from string operations; that is, --share pid,mnt=/foo would be reconstructed as --share pid=/foo/pid --share mnt=/foo/mnt. The problem with this approach is that this doesn't work well with magic links to file descriptors in /proc.

Instead, we now open the directory path and use its file descriptor to open further nsfs files.