### PR TITLE
tty: handle SIGHUP when allocating a tty

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -395,6 +395,8 @@ int enter(struct entry_settings *opts)
 			/* tty_parent_setup handles SIGWINCH to resize the pty */
 			sigdelset(&mask, SIGWINCH);
 			tty_parent_setup(&opts->ttyopts, epollfd, socket_fdpass[SOCKET_PARENT]);
+			/* handle SIGHUP to close the pty master */
+			sigdelset(&mask, SIGHUP);
 		}
 		sig_setup(epollfd, &mask, outer_helper.pid, sig_handler);
 

--- a/enter.c
+++ b/enter.c
@@ -392,11 +392,10 @@ int enter(struct entry_settings *opts)
 		sigfillset(&mask);
 
 		if (opts->tty) {
-			/* tty_parent_setup handles SIGWINCH to resize the pty */
+			/* tty_parent_setup handles SIGWINCH to resize the pty and SIGHUP to close the pty master */
 			sigdelset(&mask, SIGWINCH);
-			tty_parent_setup(&opts->ttyopts, epollfd, socket_fdpass[SOCKET_PARENT]);
-			/* handle SIGHUP to close the pty master */
 			sigdelset(&mask, SIGHUP);
+			tty_parent_setup(&opts->ttyopts, epollfd, socket_fdpass[SOCKET_PARENT]);
 		}
 		sig_setup(epollfd, &mask, outer_helper.pid, sig_handler);
 


### PR DESCRIPTION
When a session is hung up and a tty is allocated SIGHUP will be sent
to all processes in the session group.  Since we were ignoring SIGHUP
this led to bst processes hanging around.

Add signal handling for SIGHUP to close the tty master.  This will lead
to cleanup of the child session.

Fixes: 1047634