### PR TITLE
add an option to skip draining on tty close

### DIFF
--- a/main.c
+++ b/main.c
@@ -789,6 +789,7 @@ int main(int argc, char *argv[], char *envp[])
 			{
 				opts.tty = 1;
 				opts.ttyopts.ptmx = tty_default_ptmx;
+				opts.ttyopts.drain = true;
 
 				/* 128 is enough to support everything */
 				struct kvlist kvlist[128];

--- a/man/bst.1.scd
+++ b/man/bst.1.scd
@@ -371,6 +371,9 @@ spacetime process.
 	- *ptmx*=<path>: use the specified ptmx device (relative to the target root)
 	  to allocated the pty.
 
+	- *drain*: whether to drain the tty on stdin closure.  The default is true,
+	  so prepend a _'-'_ to this option to prevent draining.
+
 	By default bst inherits the parent's terminal device (or lack thereof).  Use
 	the --tty option to allocate a new pty for the child process.
 

--- a/tty.c
+++ b/tty.c
@@ -362,9 +362,7 @@ void tty_parent_setup(struct tty_opts *opts, int epollfd, int socket)
 
 	struct termios tios;
 
-	if (opts->drain != NULL) {
-		info.drain = *opts->drain;
-	}
+	info.drain = opts->drain;
 
 	info.stdinIsatty = tcgetattr(STDIN_FILENO, &tios) == 0;
 	if (!info.stdinIsatty && errno != ENOTTY) {
@@ -669,8 +667,7 @@ static void parse_drain(struct tty_opts *opts, const char *key, const char *val,
 	if (val != NULL) {
 		errx(2, "tty option '%s' must have no value", key);
 	}
-	opts->drain = malloc(sizeof(bool));
-	*opts->drain = (key[0] != '-');
+	opts->drain = (key[0] != '-');
 }
 
 static int cmp_flag(const void *key, const void *elem)

--- a/tty.h
+++ b/tty.h
@@ -15,6 +15,7 @@ struct tty_opts {
 	const char *ptmx;
 	struct termios termios;
 	struct termios neg_termios;
+	bool *drain;
 };
 
 extern const char *tty_default_ptmx;

--- a/tty.h
+++ b/tty.h
@@ -15,7 +15,7 @@ struct tty_opts {
 	const char *ptmx;
 	struct termios termios;
 	struct termios neg_termios;
-	bool *drain;
+	bool drain;
 };
 
 extern const char *tty_default_ptmx;


### PR DESCRIPTION
When ssh connections to buses are terminated bst is blocking while
draining the pty.  The signal handler does to run in this case and
the process hangs around until the bus is rebooted.

Added an option to control whether or not the pty is drained when
stdin is closed.  The b5c bst invocation will pass --tty=-drain.
