### PR TITLE
cgroup: initialize controllers buffer to 0s

### DIFF
--- a/cgroup.c
+++ b/cgroup.c
@@ -282,7 +282,7 @@ void cgroup_start_cleaner(int parentfd, const char *name)
 
 void cgroup_enable_controllers(int cgroupfd)
 {
-	char controllers[BUFSIZ];
+	char controllers[BUFSIZ] = {0};
 	int cfd = openat(cgroupfd, "cgroup.controllers", O_RDONLY, 0);
 	if (cfd == -1) {
 		err(1, "cgroup_enable_controllers: open cgroup.controllers");


### PR DESCRIPTION
Initialize controllers buffer to 0s in case there are no cgroups controllers and reading "cgroup.controllers" results in 0 bytes.

Without this, the controllers buffer contents is undefined and then later on we attempt to strtok on the undefined buffer to split it on spaces which can yield undefined results.