### PR TITLE
seccomp: handle ENOENT when receiving syscall

### DIFF
--- a/sec.c
+++ b/sec.c
@@ -690,6 +690,9 @@ noreturn void sec_seccomp_supervisor(int seccomp_fd)
 
 		if (ioctl(seccomp_fd, SECCOMP_IOCTL_NOTIF_RECV, req) == -1) {
 			switch (errno) {
+			case ENOENT:
+				/* Target was killed during the syscall but before we have
+				   the chance to handle it */
 			case EINTR:
 				continue;
 			case ENOTTY:


### PR DESCRIPTION
The SECCOMP_IOCTL_NOTIF_RECV ioctl can fail with ENOENT if the target thread gets killed while it's blocked in a syscall the seccomp supervisor is handling, but before the supervisor manages to read any information about that system call.

This commit fixes this oversight by retrying on ENOENT.