### PR TITLE
outer: fix pdeathsig race causing the helper to survive its parent

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -448,6 +448,8 @@ int enter(struct entry_settings *opts)
 		err(1, "open /proc/self");
 	}
 
+	/* This needs to be closed before sig_setpdeathsig, since holding onto
+	   the keep end means the check end will always read-block. */
 	close(liveness_fds[LIVENESS_KEEP]);
 
 	/* err() and errx() cannot use exit(), since it's not fork-safe. */

--- a/outer.c
+++ b/outer.c
@@ -258,6 +258,10 @@ void outer_helper_spawn(struct outer_helper *helper)
 		return;
 	}
 
+	/* This needs to be closed before sig_setpdeathsig, since holding onto
+	   the keep end means the check end will always read-block. */
+	close(liveness_fds[LIVENESS_KEEP]);
+
 	sig_setpdeathsig(SIGKILL, liveness_fds[LIVENESS_CHECK]);
 
 	/* Make sure all file descriptors except for the ones we're actually using


### PR DESCRIPTION
The outer helper would call sig_pdeathsig but still hold onto the KEEP (write) end of the pipe, causing the CHECK (read) end to always cause reads to return EAGAIN. This commit fixes this by closing the KEEP end in the child properly prior to calling the function.