### PR TITLE
test: add CGROUP_PATH to expected environment

### DIFF
--- a/test/bst.t
+++ b/test/bst.t
@@ -252,6 +252,7 @@ Testing Environment
 	FOO=bar
 	ROOT=/
 	EXECUTABLE=/bin/true
+	CGROUP_PATH=/sys/fs/cgroup
 
 	$ bst --no-env -- FOO-BAR=baz env
 	FOO-BAR=baz


### PR DESCRIPTION
This is causing the barney.ci/bst tests to fail.