### PR TITLE
seccomp: fix mknod emulation

### DIFF
--- a/capable.c
+++ b/capable.c
@@ -46,7 +46,7 @@ void init_capabilities(void)
 bool capable(uint64_t cap)
 {
 	uint64_t caps = (uint64_t) current[1].effective << 32 | current[0].effective;
-	return caps & ((uint64_t)1 << cap);
+	return caps & cap;
 }
 
 void make_capable(uint64_t cap)

--- a/capable.h
+++ b/capable.h
@@ -10,6 +10,7 @@
 # include <stdbool.h>
 # include <stdint.h>
 # include <linux/capability.h>
+# include <unistd.h>
 
 /* Define more useful capability constants */
 # define BST_CAP_SYS_ADMIN      ((uint64_t) 1 << CAP_SYS_ADMIN)
@@ -29,6 +30,14 @@ bool capable(uint64_t cap);
 void make_capable(uint64_t cap);
 void reset_capabilities(void);
 void drop_capabilities(void);
+
+struct capabilities {
+	uint64_t inheritable;
+	uint64_t permitted;
+	uint64_t effective;
+};
+
+int tid_capget(pid_t tid, struct capabilities *capabilities);
 
 # define with_capable(capmask) \
 	for (int __ok = ((void) make_capable(capmask), 1); __ok; (void) reset_capabilities(), __ok = 0)

--- a/mount.h
+++ b/mount.h
@@ -19,4 +19,12 @@ struct mount_entry {
 void mount_entries(const char *root, const struct mount_entry *mounts, size_t nmounts, int no_derandomize);
 void mount_mutables(const char *root, const char *const *mutables, size_t nmutables);
 
+struct devtmpfs_device {
+	const char *path;
+	mode_t mode;
+	dev_t dev;
+};
+
+extern const struct devtmpfs_device devtmpfs_safe_devices[];
+
 #endif /* !MOUNT_H */

--- a/proc.c
+++ b/proc.c
@@ -5,6 +5,7 @@
  */
 
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -24,6 +25,8 @@ int proc_read_status(int procfd, struct proc_status *out)
 	char line[4096];
 	while (fgets(line, sizeof (line) - 1, f)) {
 		sscanf(line, "Umask:\t%o\n", &out->umask);
+		sscanf(line, "Uid:\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\n", &out->ruid, &out->euid, &out->suid, &out->fsuid);
+		sscanf(line, "Gid:\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\t%" PRIu32 "\n", &out->rgid, &out->egid, &out->sgid, &out->fsgid);
 	}
 
 	fclose(f);

--- a/proc.h
+++ b/proc.h
@@ -7,8 +7,18 @@
 #ifndef PROC_H_
 # define PROC_H_
 
+# include <unistd.h>
+
 struct proc_status {
 	mode_t umask;
+	uid_t ruid;
+	uid_t euid;
+	uid_t suid;
+	uid_t fsuid;
+	gid_t rgid;
+	gid_t egid;
+	gid_t sgid;
+	gid_t fsgid;
 };
 
 int proc_read_status(int procfd, struct proc_status *out);


### PR DESCRIPTION
This PR provides some changes to enhance the emulated mknod system call in the seccomp supervisor.

The main changes are:
* The seccomp supervisor now detects when there are no users to the filter and exit rather than spinning freely until it gets killed
* Devices that were specified for inclusion in our fake devtmpfs are now automatically deemed safe in the emulated mknod
* The emulated mknod will now operate with the same effective IDs as the target thread
* The emulated mknod will now check that the target thread has CAP_MKNOD for accuracy